### PR TITLE
736 pass exp date to authorize net on refund

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net.rb
@@ -153,7 +153,7 @@ module ActiveMerchant #:nodoc:
       # * <tt>:first_name</tt> -- The first name of the account being refunded.
       # * <tt>:last_name</tt> -- The last name of the account being refunded.
       # * <tt>:zip</tt> -- The postal code of the account being refunded.
-      # * <tt>:exp_date</tt> -- The credit card expiration_date the refund is being issued to. Needed in the event that the card you wish to issue a credit for is expired and the cardholder has provided a new expiration date for the same card.
+      # * <tt>:exp_date</tt> -- The credit card expiration_date the refund is being issued to. Needed in the event that the card you wish to issue a credit for is expired and the cardholder has provided a new expiration date for the same card. See the following link for acceptable formats: http://developer.authorize.net/guides/AIM/Transaction_Data_Requirements/Transaction_Information.htm
       def refund(money, identification, options = {})
         requires!(options, :card_number)
 

--- a/test/unit/gateways/authorize_net_test.rb
+++ b/test/unit/gateways/authorize_net_test.rb
@@ -121,12 +121,12 @@ class AuthorizeNetTest < Test::Unit::TestCase
   
   def test_refund_passing_extra_info
     response = stub_comms do
-      @gateway.refund(50, '123456789', :card_number => @credit_card.number, :first_name => "Bob", :last_name => "Smith", :zip => "12345", :exp_date => "09#{@credit_card.year}")
+      @gateway.refund(50, '123456789', :card_number => @credit_card.number, :first_name => "Bob", :last_name => "Smith", :zip => "12345", :exp_date => "0915")
     end.check_request do |endpoint, data, headers|
       assert_match(/x_first_name=Bob/, data)
       assert_match(/x_last_name=Smith/, data)
       assert_match(/x_zip=12345/, data)
-      assert_match(/x_exp_date=09#{@credit_card.year}/, data)
+      assert_match(/x_exp_date=0915/, data)
     end.respond_with(successful_purchase_response)
     assert_success response
   end


### PR DESCRIPTION
- The exp_date is a neccessary parameter in the event that the
  card you wish to refund has expired and the customer has
  supplied a new expiration date for that card
