### PR TITLE
Pass cvv on card update

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -105,6 +105,7 @@ module ActiveMerchant #:nodoc:
           credit_card_params = merge_credit_card_options({
             :credit_card => {
               :number => creditcard.number,
+              :cvv => creditcard.verification_value,
               :expiration_month => creditcard.month.to_s.rjust(2, "0"),
               :expiration_year => creditcard.year.to_s
             }


### PR DESCRIPTION
Always passing the CVV allows for "updating a credit card and explicitly
verifying the card" at the same time:
https://www.braintreepayments.com/docs/ruby/general/card_verification#credit_card_api
