### PR TITLE
Include extra options

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -656,7 +656,8 @@ module ActiveMerchant #:nodoc:
                 tag_unless_blank(xml,'customerShippingAddressId', transaction[:customer_shipping_address_id])
                 xml.tag!('transId', transaction[:trans_id])
               when :refund
-                #TODO - add lineItems and extraOptions fields 
+                #TODO - add lineItems
+                xml.tag!('extraOptions', xml.cdata!(build_extra_options_string(@options))) if @options[:ip] || @options[:extra_options]
                 xml.tag!('amount', transaction[:amount])
                 tag_unless_blank(xml, 'customerProfileId', transaction[:customer_profile_id])
                 tag_unless_blank(xml, 'customerPaymentProfileId', transaction[:customer_payment_profile_id])
@@ -681,6 +682,12 @@ module ActiveMerchant #:nodoc:
             add_order(xml, transaction[:order]) if transaction[:order].present?
           end
         end
+      end
+
+      def build_extra_options_string(options)
+        options[:extra_options].reverse_merge!(:x_customer_ip => options[:ip]) if options[:ip]
+        extra_options = options[:extra_options].map {|key, value| "#{key}=#{value}" }
+        extra_options.join("&")
       end
 
       def add_tax(xml, tax)

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -584,6 +584,19 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal 'This transaction has been approved.', response.params['direct_response']['message']
   end
 
+  def test_should_include_customer_ip_option
+    options = {:ip => '0.0.0.0',
+               :extra_options => {:x_foo => 'bar'}}
+    assert_equal "x_foo=bar&x_customer_ip=0.0.0.0", @gateway.send(:build_extra_options_string,options)
+  end
+
+  def test_should_not_overwrite_explicit_ip_option
+    options = {:ip => '0.0.0.0',
+               :extra_options => {:x_foo => 'bar',
+                                  :x_customer_ip => '1.1.1.1'}}
+    assert_equal "x_foo=bar&x_customer_ip=1.1.1.1", @gateway.send(:build_extra_options_string,options)
+  end
+
   private
   
   def get_auth_only_response


### PR DESCRIPTION
- Includes any key/values passed in under the :extra_options hash
- Includes the x_customer_ip extra option when the :ip option is present
