### PR TITLE
Hack to change ClientType to MOTO

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -57,7 +57,7 @@ module ActiveMerchant #:nodoc:
       def purchase(money, payment_source, options = {})
         request = build_purchase_or_authorization_request(money, payment_source, options)
         
-        request.add_element("ClientType").text = "Recurring"
+        request.add_element("ClientType").text = "MOTO"
         
         commit(:purchase, request)      
       end


### PR DESCRIPTION
This has been recommended by PaymentExpress as a way to
work around the CVC2 Mandate for recurring transactions
(MOTO clients are exempt) while still passing the expiry
information all the way to the acquirer (transacations
for ClientType=Recurring did not send expiry info)
