### PR TITLE
Limit PaymentExpress MerchantReference (description) to 64 chars

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -215,7 +215,7 @@ module ActiveMerchant #:nodoc:
       
       def add_invoice(xml, options)
         xml.add_element("TxnId").text = options[:order_id].to_s.slice(0, 16) unless options[:order_id].blank?
-        xml.add_element("MerchantReference").text = options[:description] unless options[:description].blank?
+        xml.add_element("MerchantReference").text = options[:description].to_s.slice(0, 64) unless options[:description].blank?
       end
       
       def add_address_verification_data(xml, options)

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -148,6 +148,42 @@ class PaymentExpressTest < Test::Unit::TestCase
     assert_nil response.cvv_result['code']
   end
   
+  def test_purchase_truncates_order_id_to_16_chars
+    @gateway.expects(:ssl_post).with do |url, xml|
+      doc = REXML::Document.new(xml)
+      doc.root.get_text("TxnId") == "16chars---------"
+    end
+
+    @gateway.purchase(@amount, @visa, {:order_id => "16chars---------EXTRA"})
+  end
+
+  def test_purchase_truncates_description_to_64_chars
+    @gateway.expects(:ssl_post).with do |url, xml|
+      doc = REXML::Document.new(xml)
+      doc.root.get_text("MerchantReference") == "64chars---------------------------------------------------------"
+    end
+
+    @gateway.purchase(@amount, @visa, {:description => "64chars---------------------------------------------------------EXTRA"})
+  end
+
+  def test_authorize_truncates_order_id_to_16_chars
+    @gateway.expects(:ssl_post).with do |url, xml|
+      doc = REXML::Document.new(xml)
+      doc.root.get_text("TxnId") == "16chars---------"
+    end
+
+    @gateway.authorize(@amount, @visa, {:order_id => "16chars---------EXTRA"})
+  end
+
+  def test_authorize_truncates_description_to_64_chars
+    @gateway.expects(:ssl_post).with do |url, xml|
+      doc = REXML::Document.new(xml)
+      doc.root.get_text("MerchantReference") == "64chars---------------------------------------------------------"
+    end
+
+    @gateway.authorize(@amount, @visa, {:description => "64chars---------------------------------------------------------EXTRA"})
+  end
+
   private
 
   def billing_id_token_purchase(options = {})


### PR DESCRIPTION
PaymentExpress enforces a max length on the MerchantReference field of 64 characters.  This field is derived from the description field passed in options
