### PR TITLE
add 'reference' attr to CreditCard

### DIFF
--- a/lib/active_merchant/billing/credit_card.rb
+++ b/lib/active_merchant/billing/credit_card.rb
@@ -117,6 +117,15 @@ module ActiveMerchant #:nodoc:
       # @return [String]
       attr_accessor :track_data
 
+      # Returns or sets a card reference value.
+      #
+      # This attribute is optional and is for setting a reference value for a
+      # card on gateway that support multiple payment methods (cards) on a
+      # payer.
+      #
+      # @return [String] the reference value
+      attr_accessor :reference
+
       def type
         self.class.deprecated "CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead."
         brand
@@ -139,6 +148,11 @@ module ActiveMerchant #:nodoc:
       # @return +true+ if the card has expired, +false+ otherwise
       def expired?
         expiry_date.expired?
+      end
+
+      # Returns whether the +reference+ attribute has been set.
+      def reference?
+        @reference.present?
       end
 
       # Returns whether either the +first_name+ or the +last_name+ attributes has been set.

--- a/test/unit/credit_card_test.rb
+++ b/test/unit/credit_card_test.rb
@@ -370,7 +370,7 @@ class CreditCardTest < Test::Unit::TestCase
     assert !card.valid?
     assert_equal "", card.number
   end
-  
+
   def test_brand_is_aliased_as_type
     assert_deprecation_warning("CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead.", CreditCard) do
       assert_equal @visa.type, @visa.brand
@@ -378,5 +378,13 @@ class CreditCardTest < Test::Unit::TestCase
     assert_deprecation_warning("CreditCard#type is deprecated and will be removed from a future release of ActiveMerchant. Please use CreditCard#brand instead.", CreditCard) do
       assert_equal @solo.type, @solo.brand
     end
+  end
+
+  def test_should_be_true_when_credit_card_has_a_reference
+    c = CreditCard.new
+    assert_false c.reference?
+
+    c = CreditCard.new(:reference => 'visa01')
+    assert c.reference?
   end
 end


### PR DESCRIPTION
This adds a reference attribute to CreditCard (credit_card.reference)
that is for setting a special value for that card. A good example is
usage with the Realex gateway.

Realex requires a reference value for credit cards stored because there
are 'payment methods' on 'payer'. Realex uses the reference on the
stored card when making transactions as a token along with the payer
reference.
