### PR TITLE
don't pass email address if :set_default is true

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -102,7 +102,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_creditcard(post, creditcard, options)
         post[:description] = options[:description]
-        post[:email] = options[:email]
+        post[:email] = options[:email] unless options[:set_default]
 
         commit_options = generate_options(options)
         if options[:customer]


### PR DESCRIPTION
This stops AM from sending email addresses when cards are updated, as Stripe doesn't support email on the card endpoint.
