### PR TITLE
Quickpay: Adds currency for v7 store operations

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay.rb
+++ b/lib/active_merchant/billing/gateways/quickpay.rb
@@ -136,7 +136,7 @@ module ActiveMerchant #:nodoc:
 
           :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
-          :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
+          :subscribe => %w(protocol msgtype merchant ordernumber amount currency cardnumber
                            expirationdate cvd acquirers cardtypelock description testmode
                            fraud_remote_addr fraud_http_accept fraud_http_accept_language
                            fraud_http_accept_encoding fraud_http_accept_charset
@@ -225,6 +225,7 @@ module ActiveMerchant #:nodoc:
       def store(creditcard, options = {})
         post = {}
 
+        add_amount(post, 0, options) if @protocol >= 7 # `currency` is a required field since v7
         add_creditcard(post, creditcard, options)
         add_invoice(post, options)
         add_description(post, options)


### PR DESCRIPTION
While working with Quickpay in production mode, it has been discovered
that "currency" is a required value for store (subscribe) operations in
the v7 API.  Without it, subscribe operations complain with "Error in
request parameters". This is confirmed by their documentation, which
currently states that currency is required:
http://doc.quickpay.net/api/messagetypes.html#index2h2

This commit makes the change such that only the subscribe parameters for
v7 (and up) are changed.  New unit tests were added to prove the correct
parameters are now being sent, and all existing remote tests were run
and are passing.
