### PR TITLE
Updates FirstData e4 gateway to send correct card types

### DIFF
--- a/lib/active_merchant/billing/gateways/firstdata_e4.rb
+++ b/lib/active_merchant/billing/gateways/firstdata_e4.rb
@@ -23,7 +23,15 @@ module ActiveMerchant #:nodoc:
 
       SENSITIVE_FIELDS = [:verification_str2, :expiry_date, :card_number]
 
-      self.supported_cardtypes = [:visa, :master, :american_express, :jcb, :discover]
+      BRANDS = {
+        :visa => 'Visa',
+        :master => "Mastercard",
+        :american_express => "American Express",
+        :jcb => "JCB",
+        :discover => "Discover"
+      }
+
+      self.supported_cardtypes = BRANDS.keys
       self.supported_countries = ["CA", "US"]
       self.default_currency = "USD"
       self.homepage_url = "http://www.firstdata.com"
@@ -168,7 +176,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! "Card_Number", credit_card.number
         xml.tag! "Expiry_Date", expdate(credit_card)
         xml.tag! "CardHoldersName", credit_card.name
-        xml.tag! "CardType", credit_card.brand
+        xml.tag! "CardType", card_type(credit_card.brand)
 
         add_credit_card_verification_strings(xml, credit_card, options)
       end
@@ -199,7 +207,7 @@ module ActiveMerchant #:nodoc:
         xml.tag! "TransarmorToken", params[0]
         xml.tag! "Expiry_Date", expdate(credit_card)
         xml.tag! "CardHoldersName", credit_card.name
-        xml.tag! "CardType", credit_card.brand
+        xml.tag! "CardType", card_type(credit_card.brand)
       end
 
       def add_customer_data(xml, options)
@@ -221,6 +229,10 @@ module ActiveMerchant #:nodoc:
 
       def expdate(credit_card)
         "#{format(credit_card.month, :two_digits)}#{format(credit_card.year, :two_digits)}"
+      end
+
+      def card_type(credit_card_brand)
+        BRANDS[credit_card_brand.to_sym] if credit_card_brand
       end
 
       def commit(action, request, credit_card = nil)

--- a/test/unit/gateways/firstdata_e4_test.rb
+++ b/test/unit/gateways/firstdata_e4_test.rb
@@ -20,6 +20,10 @@ class FirstdataE4Test < Test::Unit::TestCase
     @authorization = "ET1700;106625152;4738"
   end
 
+  def test_supported_cardtypes
+    assert_equal [:visa, :master, :american_express, :jcb, :discover], FirstdataE4Gateway.supported_cardtypes
+  end
+
   def test_successful_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.purchase(@amount, @credit_card, @options)
@@ -54,7 +58,7 @@ class FirstdataE4Test < Test::Unit::TestCase
     assert response = @gateway.store(@credit_card, @options)
     assert_success response
     assert_equal '8938737759041111', response.params['transarmor_token']
-    assert_equal '8938737759041111;visa;Longbob;Longsen;9;2014', response.authorization
+    assert_equal '8938737759041111;visa;Longbob;Longsen;9;2015', response.authorization
   end
 
   def test_failed_store_without_transarmor_support
@@ -115,6 +119,14 @@ class FirstdataE4Test < Test::Unit::TestCase
     end.check_request do |endpoint, data, headers|
       assert_match "<VerificationStr1>1234 My Street|K1C2N6|Ottawa|ON|CA</VerificationStr1>", data
     end.respond_with(successful_purchase_response)
+  end
+
+  def test_card_type
+    assert_equal 'Visa', @gateway.send(:card_type, 'visa')
+    assert_equal 'Mastercard', @gateway.send(:card_type, 'master')
+    assert_equal 'American Express', @gateway.send(:card_type, 'american_express')
+    assert_equal 'JCB', @gateway.send(:card_type, 'jcb')
+    assert_equal 'Discover', @gateway.send(:card_type, 'discover')
   end
 
   private


### PR DESCRIPTION
Masercard and amex transactions are failing because of an incorrect CardType in the XML
