### PR TITLE
PayMill Updates

### DIFF
--- a/lib/active_merchant/billing/gateways/paymill.rb
+++ b/lib/active_merchant/billing/gateways/paymill.rb
@@ -46,7 +46,27 @@ module ActiveMerchant #:nodoc:
       end
 
       def store(credit_card, options={})
-        save_card(credit_card)
+        # Paymill returns a token that is only good for one use
+        # The recommended approach for recurring is to convert
+        # the token into a Payment, which can be used multiple times.
+        if options[:convert_token]
+          MultiResponse.run do |r|
+            # Store the card, get back a token (i.e. tok_abc123 )
+            r.process { save_card(credit_card) }
+            # Convert the token into a Payment object, which represents a card (i.e. pay_abc456 )
+            r.process { convert_token_to_payment(r.authorization) }
+          end
+        else
+          save_card(credit_card)
+        end
+      end
+
+      def unstore(payment_id)
+        commit(:delete, "payments/#{CGI.escape(payment_id)}", nil)
+      end
+
+      def convert_token_to_payment(token)
+        commit(:post, 'payments', { :token => token })
       end
 
       private
@@ -74,17 +94,17 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, response_message(parsed), parsed, {})
         end
 
-        response_from(raw_response)
+        response_from(raw_response, url)
       end
 
-      def response_from(raw_response)
+      def response_from(raw_response, url)
         parsed = JSON.parse(raw_response)
         options = {
           :authorization => authorization_from(parsed),
           :test => (parsed['mode'] == 'test'),
         }
 
-        succeeded = (parsed['data'] == []) || (parsed['data']['response_code'] == 20000)
+        succeeded = (parsed['data'] == []) || (parsed['data']['response_code'] == 20000) || (url == 'payments' && parsed['data']['id'].present?)
         Response.new(succeeded, response_message(parsed), parsed, options)
       end
 
@@ -101,7 +121,11 @@ module ActiveMerchant #:nodoc:
       def action_with_token(action, money, payment_method, options)
         case payment_method
         when String
-          self.send("#{action}_with_token", money, payment_method, options)
+          if payment_method =~ /\Apay_/
+            self.send("#{action}_with_payment", money, payment_method, options)
+          else
+            self.send("#{action}_with_token", money, payment_method, options)
+          end
         else
           MultiResponse.run do |r|
             r.process { save_card(payment_method) }
@@ -115,6 +139,15 @@ module ActiveMerchant #:nodoc:
 
         add_amount(post, money, options)
         post[:token] = card_token
+        post[:description] = options[:description]
+        commit(:post, 'transactions', post)
+      end
+
+      def purchase_with_payment(money, payment_id, options)
+        post = {}
+
+        add_amount(post, money, options)
+        post[:payment] = payment_id
         post[:description] = options[:description]
         commit(:post, 'transactions', post)
       end

--- a/test/remote/gateways/remote_paymill_test.rb
+++ b/test/remote/gateways/remote_paymill_test.rb
@@ -104,6 +104,24 @@ class RemotePaymillTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_store_with_multiple_purchases
+    store = @gateway.store(@credit_card)
+    assert_success store
+    assert_not_nil store.authorization
+
+    # Do first purchase with the token (i.e. tok_abc123)
+    purchase_1 = @gateway.purchase(@amount, store.authorization)
+    payment_id = purchase_1.params['data']['payment']['id']
+
+    # Do next payment with the payment id (i.e. pay_abc123)
+    purchase_2 = @gateway.purchase(@amount, payment_id, { description: 'something' })
+    assert_success purchase_2
+
+    # Do subsequent payments with the same payment id (i.e. pay_abc123)
+    purchase_3 = @gateway.purchase(@amount, payment_id, { description: 'something else' })
+    assert_success purchase_3
+  end
+
   def test_failed_store_with_invalid_card
     @credit_card.number = ''
     assert response = @gateway.store(@credit_card)


### PR DESCRIPTION
PayMill Updates:
- Allow purchase to take a payment_id as well as a token
- Use a Multiresponse to optionally tore and convert a token
