### PR TITLE
[bugfix] Fix elavon undefined method error

### DIFF
--- a/lib/active_merchant/billing/gateways/elavon.rb
+++ b/lib/active_merchant/billing/gateways/elavon.rb
@@ -326,7 +326,7 @@ module ActiveMerchant #:nodoc:
         resp = {}
         msg.split(self.delimiter).collect{|li|
             key, value = li.split("=")
-            resp[key.strip.gsub(/^ssl_/, '')] = value.to_s.strip
+            resp[key.to_s.strip.gsub(/^ssl_/, '')] = value.to_s.strip
           }
         resp
       end


### PR DESCRIPTION
Fixes this error:

`undefined method`strip' for nil:NilClass`
