### PR TITLE
[bugfix] Uses the correct method to delete existing paypal accounts

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -274,7 +274,7 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, 'Braintree::NotFoundError') if customer.nil?
 
           # Delete the customers existing payment methods
-          customer.paypal_accounts.each {|pp| Braintree::PayPalAccount.delete(pp.token)}
+          customer.paypal_accounts.each { |pp| @braintree_gateway.paypal_account.delete(pp.token) }
 
           # Update it with the new nonce
           result = @braintree_gateway.customer.update(vault_id,


### PR DESCRIPTION
We were trying to use the uninitialized `Braintree::PaypalAccount` class here which was resulting in a `Braintree::ConfigurationError`. Instead, we update to use `braintree_gateway`, which is pre-configured in the constructor.