### PR TITLE
[fusebox] Switch store from $0 auth to $1 auth

### DIFF
--- a/lib/active_merchant/billing/gateways/fusebox.rb
+++ b/lib/active_merchant/billing/gateways/fusebox.rb
@@ -130,7 +130,7 @@ module ActiveMerchant #:nodoc:
 
       # Storing a card is done via an authorize for $0.00 with the string "ID:" in the token request field
       def store(creditcard, options = {})
-        authorize(0, creditcard, options.merge(:token_request => 'ID:'))
+        authorize(100, creditcard, options.merge(:token_request => 'ID:'))
       end
 
       # For a successful void, options must include same :reference of a

--- a/test/unit/gateways/fusebox_test.rb
+++ b/test/unit/gateways/fusebox_test.rb
@@ -61,7 +61,7 @@ class FuseboxTest < Test::Unit::TestCase
   end
 
   def test_successful_store
-    @gateway.expects(:build_request).with(:token_request => 'ID:', :transaction_qualifier => '010', :transaction_amount => '0.00', :unique_reference => 8888888, :billing_zip_code => '', :billing_address => '', :cashier_id => '0', :customer_code => 8888888, :account_number => '4242424242424242', :expiration => '0917', :cvc => '123', :transaction_type => '01')
+    @gateway.expects(:build_request).with(:token_request => 'ID:', :transaction_qualifier => '010', :transaction_amount => '1.00', :unique_reference => 8888888, :billing_zip_code => '', :billing_address => '', :cashier_id => '0', :customer_code => 8888888, :account_number => '4242424242424242', :expiration => '0917', :cvc => '123', :transaction_type => '01')
     @gateway.expects(:ssl_post).returns(successful_store_response)
 
     assert response = @gateway.store(@credit_card, @options)


### PR DESCRIPTION
It appears that not all banks support the $0 auth, even though the fusebox documentation recommends it as the way to store a card.

This switches from a $0 auth to a $1 auth in an attempt at a more reliable way to store cards.  Note that Visa mandates warn that there may be fees for "Authorization System Misuse", but since support for $0 seems to still be problematic, we don't feel these fees will ever materialize.