### PR TITLE
eWAY Rapid 3.1 gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/eway_rapid31.rb
+++ b/lib/active_merchant/billing/gateways/eway_rapid31.rb
@@ -1,0 +1,323 @@
+require 'json'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class EwayRapid31Gateway < Gateway
+      self.test_url = 'https://api.sandbox.ewaypayments.com/'
+      self.live_url = 'https://api.ewaypayments.com/'
+
+      self.money_format     = :cents
+      self.default_currency = 'AUD'
+
+      self.supported_countries = ['AU', 'NZ', 'GB']
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club]
+
+      self.homepage_url = 'http://www.eway.com.au'
+      self.display_name = 'eWAY Rapid 3.1'
+
+      def initialize(options = {})
+        requires!(options, :login, :password)
+
+        super
+      end
+
+      def purchase(money, credit_card_or_token, options = {})
+        post = {}
+        post[:Payment] ||= {}
+
+        add_invoice(post[:Payment], options)
+        add_amount(post[:Payment], money, options)
+        add_credit_card(post, credit_card_or_token)
+        add_customer_data(post, options)
+        add_metadata(post, options)
+
+        commit('Transaction', post)
+      end
+
+      # store requires that address or billing_address have :country and :name
+      # set due to legacy API
+      def store(credit_card, options = {})
+        post = {}
+
+        add_credit_card(post, credit_card)
+        add_customer_data(post, options)
+
+        commit('Customer', post)
+      end
+
+      def refund(money, identification, options = {})
+        post = {}
+        post[:Refund] ||= {}
+        post[:Refund][:TransactionID] = identification.to_s
+
+        add_invoice(post[:Refund], options)
+        add_amount(post[:Refund], money, options)
+        add_customer_data(post, options)
+        add_metadata(post, options)
+
+        commit("Transaction/#{identification}/Refund", post)
+      end
+
+      def update(token, credit_card, options = {})
+        post = {}
+        post[:Customer] ||= {}
+        post[:Customer][:TokenCustomerID] = token.to_s
+
+        add_customer_data(post, options)
+        add_credit_card(post, credit_card)
+        add_metadata(post, options)
+
+        commit('Customer', post, :put)
+      end
+
+      private
+
+      def url_for(endpoint)
+        (test? ? test_url : live_url) + endpoint
+      end
+
+      def add_amount(post, money, options)
+        post ||= {}
+        post[:TotalAmount]  = amount(money).to_i
+        post[:CurrencyCode] = options[:currency] || currency(money)
+      end
+
+      def add_customer_data(post, options)
+        post[:Customer] ||= {}
+
+        if address = options[:billing_address] || options[:address]
+          post[:Customer].merge! translated_address_hash(post, address, { :email => options[:email] })
+        end
+
+        if options[:shipping_address]
+          post[:ShippingAddress] = translated_address_hash(post, options[:shipping_address])
+          post[:ShippingAddress].reject! { |field| [:Fax, :CompanyName, :Mobile, :Title].include?(:field) }
+        end
+      end
+
+      def translated_address_hash(post, address, options)
+        return unless address
+
+        output = {}
+
+        if name = address[:name]
+          parts = name.split(/\s+/)
+
+          output[:FirstName] = parts.shift if parts.size > 1
+          output[:LastName]  = parts.join(' ')
+        end
+
+        output[:Title]       = address[:title].to_s
+        output[:CompanyName] = address[:company]
+        output[:Street1]     = address[:address1]
+        output[:Street2]     = address[:address2]
+        output[:City]        = address[:city]
+        output[:State]       = address[:state]
+        output[:PostalCode]  = address[:zip]
+        output[:Country]     = address[:country].to_s.downcase
+        output[:Phone]       = address[:phone]
+        output[:Mobile]      = address[:mobile].to_s
+        output[:Fax]         = address[:fax]
+        output[:Email]       = options[:email] if options[:email]
+
+        output
+      end
+
+      def add_invoice(post, options)
+        post ||= {}
+        post[:InvoiceReference]   = options[:order_id]
+        post[:InvoiceDescription] = options[:description]
+      end
+
+      def add_credit_card(post, credit_card_or_token)
+        post[:Customer] ||= {}
+
+        if credit_card_or_token.is_a?(String) || credit_card_or_token.is_a?(Integer)
+          post[:Customer][:TokenCustomerID] = credit_card_or_token.to_s
+        else
+          post[:Customer][:CardDetails] ||= {}
+          post[:Customer][:CardDetails][:Name]        = credit_card_or_token.name
+          post[:Customer][:CardDetails][:Number]      = credit_card_or_token.number
+          post[:Customer][:CardDetails][:ExpiryMonth] = sprintf('%02d', credit_card_or_token.month)
+          post[:Customer][:CardDetails][:ExpiryYear]  = credit_card_or_token.year.to_s[2,2]
+          post[:Customer][:CardDetails][:CVN]         = credit_card_or_token.verification_value.to_s
+        end
+      end
+
+      def add_metadata(post, options)
+        post[:CustomerIP]      = options[:ip] if options[:ip]
+        post[:DeviceID]        = options[:application_id] || application_id
+        post[:TransactionType] = options[:transaction_type] if options[:transaction_type].present?
+      end
+
+      def parse(body)
+        JSON.parse(body)
+      end
+
+      def commit(action, post, method = :post)
+        headers = {
+          'Content-Type'  => 'application/json; charset=utf-8',
+          'Authorization' => 'Basic ' + Base64.strict_encode64(@options[:login].to_s + ':' + @options[:password].to_s).chomp
+        }
+
+        response  = parse(ssl_request(method, url_for(action), post.to_json, headers))
+        succeeded = success?(response)
+
+        Response.new(
+          succeeded,
+          message_from(succeeded, response),
+          response,
+          :authorization => authorization_from(response),
+          :test => test?,
+          :avs_result => avs_result_from(response),
+          :cvv_result => cvv_result_from(response)
+        )
+      rescue ActiveMerchant::ResponseError => e
+        Response.new(false, e.response.message, { :status_code => e.response.code}, :test => test?)
+      end
+
+      def success?(response)
+        if !response['Errors'].blank?
+          false
+        elsif ['00', '08', '10', '11', '16'].include?(response['ResponseCode'])
+          true
+        elsif response.key?('TransactionStatus')
+          response['TransactionStatus'] == true
+        else
+          true
+        end
+      end
+
+      def message_from(succeeded, response)
+        if response['Errors']
+          MESSAGES[response['Errors']] || response['Errors']
+        elsif response['ResponseCode']
+          ActiveMerchant::Billing::EwayGateway::MESSAGES[response['ResponseCode']]
+        elsif response['ResponseMessage']
+          MESSAGES[response['ResponseMessage']] || response['ResponseMessage']
+        elsif succeeded
+          'Succeeded'
+        else
+          'Failed'
+        end
+      end
+
+      def authorization_from(response)
+        response['AuthorisationCode'] || token_from(response)
+      end
+
+      def token_from(response)
+        customer_params = response['Customer']
+        customer_params.is_a?(Hash) ? customer_params['TokenCustomerID'] : nil
+      end
+
+      def avs_result_from(response)
+        return if response['Verification'].nil?
+
+        code = case response['Verification']['Address']
+               when 0 then 'M'
+               when 1 then 'N'
+               else 'I'
+               end
+
+        { :code => code }
+      end
+
+      def cvv_result_from(response)
+        return if response['Verification'].nil?
+
+        case response['Verification']['CVN']
+        when 0 then 'M'
+        when 1 then 'N'
+        else 'P'
+        end
+      end
+
+      MESSAGES = {
+              'V6000' => 'Validation error',
+              'V6001' => 'Invalid CustomerIP',
+              'V6002' => 'Invalid DeviceID',
+              'V6003' => 'Invalid Request PartnerID',
+              'V6004' => 'Invalid Request Method',
+              'V6010' => 'Invalid Payment Type, account not certified for eCom only MOTO or Recurring available',
+              'V6011' => 'Invalid Payment TotalAmount',
+              'V6012' => 'Invalid Payment InvoiceDescription',
+              'V6013' => 'Invalid Payment InvoiceNumber',
+              'V6014' => 'Invalid Payment InvoiceReference',
+              'V6015' => 'Invalid Payment CurrencyCode',
+              'V6016' => 'Payment Required',
+              'V6017' => 'Payment CurrencyCode Required',
+              'V6018' => 'Unknown Payment CurrencyCode',
+              'V6021' => 'EWAY_CARDHOLDERNAME Required',
+              'V6022' => 'EWAY_CARDNUMBER Required',
+              'V6023' => 'EWAY_CARDCVN Required',
+              'V6033' => 'Invalid Expiry Date',
+              'V6034' => 'Invalid Issue Number',
+              'V6035' => 'Invalid Valid From Date',
+              'V6040' => 'Invalid TokenCustomerID',
+              'V6041' => 'Customer Required',
+              'V6042' => 'Customer FirstName Required',
+              'V6043' => 'Customer LastName Required',
+              'V6044' => 'Customer CountryCode Required',
+              'V6045' => 'Customer Title Required',
+              'V6046' => 'TokenCustomerID Required',
+              'V6047' => 'RedirectURL Required',
+              'V6051' => 'Invalid Customer FirstName',
+              'V6052' => 'Invalid Customer LastName',
+              'V6053' => 'Invalid Customer CountryCode',
+              'V6058' => 'Invalid Customer Title',
+              'V6059' => 'Invalid RedirectURL',
+              'V6060' => 'Invalid TokenCustomerID',
+              'V6061' => 'Invalid Customer Reference',
+              'V6062' => 'Invalid Customer CompanyName',
+              'V6063' => 'Invalid Customer JobDescription',
+              'V6064' => 'Invalid Customer Street1',
+              'V6065' => 'Invalid Customer Street2',
+              'V6066' => 'Invalid Customer City',
+              'V6067' => 'Invalid Customer State',
+              'V6068' => 'Invalid Customer PostalCode',
+              'V6069' => 'Invalid Customer Email',
+              'V6070' => 'Invalid Customer Phone',
+              'V6071' => 'Invalid Customer Mobile',
+              'V6072' => 'Invalid Customer Comments',
+              'V6073' => 'Invalid Customer Fax',
+              'V6074' => 'Invalid Customer URL',
+              'V6075' => 'Invalid ShippingAddress FirstName',
+              'V6076' => 'Invalid ShippingAddress LastName',
+              'V6077' => 'Invalid ShippingAddress Street1',
+              'V6078' => 'Invalid ShippingAddress Street2',
+              'V6079' => 'Invalid ShippingAddress City',
+              'V6080' => 'Invalid ShippingAddress State',
+              'V6081' => 'Invalid ShippingAddress PostalCode',
+              'V6082' => 'Invalid ShippingAddress Email',
+              'V6083' => 'Invalid ShippingAddress Phone',
+              'V6084' => 'Invalid ShippingAddress Country',
+              'V6085' => 'Invalid ShippingAddress ShippingMethod',
+              'V6086' => 'Invalid ShippingAddress Fax ',
+              'V6091' => 'Unknown Customer CountryCode',
+              'V6092' => 'Unknown ShippingAddress CountryCode',
+              'V6100' => 'Invalid EWAY_CARDNAME',
+              'V6101' => 'Invalid EWAY_CARDEXPIRYMONTH',
+              'V6102' => 'Invalid EWAY_CARDEXPIRYYEAR',
+              'V6103' => 'Invalid EWAY_CARDSTARTMONTH',
+              'V6104' => 'Invalid EWAY_CARDSTARTYEAR',
+              'V6105' => 'Invalid EWAY_CARDISSUENUMBER',
+              'V6106' => 'Invalid EWAY_CARDCVN',
+              'V6107' => 'Invalid EWAY_ACCESSCODE',
+              'V6108' => 'Invalid CustomerHostAddress',
+              'V6109' => 'Invalid UserAgent',
+              'V6110' => 'Invalid EWAY_CARDNUMBER',
+              'V6111' => 'Unauthorised API Access, Account Not PCI Certified',
+              'V6112' => 'Redundant Card Details Other Than Expiry Year and Month',
+              'V6113' => 'Invalid Transaction for Refund',
+              'V6114' => 'Gateway Validation Error',
+              'V6115' => 'Invalid DirectRefundRequest, TransactionID',
+              'V6116' => 'Invalid card data on original transactionID',
+              'V6117' => 'Invalid CreateAccessCodeSharedRequest, FooterText',
+              'V6118' => 'Invalid CreateAccessCodeSharedRequest, HeaderText',
+              'V6119' => 'Invalid CreateAccessCodeSharedRequest, Language',
+              'V6120' => 'Invalid CreateAccessCodeSharedRequest, LogoUrl'
+            }
+    end
+  end
+end

--- a/test/remote/gateways/remote_eway_rapid31_test.rb
+++ b/test/remote/gateways/remote_eway_rapid31_test.rb
@@ -1,0 +1,141 @@
+require 'test_helper'
+
+class RemoteEwayRapid31Test < Test::Unit::TestCase
+  def setup
+    @gateway = EwayRapid31Gateway.new(fixtures(:eway_rapid))
+
+    @amount = 100
+    @credit_card = credit_card('4444333322221111')
+
+    @options = {
+      :order_id => '1',
+      :description => 'Store Purchase',
+      :email => 'jim.smith@example.com',
+      :transaction_type => 'MOTO',
+      :ip => '127.0.0.1'
+      # country and name need to be set because eWAY requires `store` to send
+      # these for legacy reasons
+    }.merge(:billing_address => { :country => 'au', :name => 'Squarebob Spongepants' })
+
+    @options_with_billing_address = @options.merge(:billing_address => address)
+
+    # require 'logger'
+    # ActiveMerchant::Billing::Gateway.wiredump_device = Logger.new(STDOUT)
+  end
+
+  def test_invalid_login
+    gateway = EwayRapid31Gateway.new(
+                :login    => '',
+                :password => ''
+              )
+
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Unauthorized', response.message
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_successful_purchase_with_billing_address
+    assert response = @gateway.purchase(@amount, @credit_card, @options_with_billing_address)
+    assert_success response
+    assert_equal 'Transaction Approved', response.message
+  end
+
+  def test_unsuccessful_purchase
+    assert response = @gateway.purchase(@amount + 1, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Refer to Issuer', response.message
+  end
+
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_successful_store_with_billing_address
+    assert response = @gateway.store(@credit_card, @options_with_billing_address)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+  end
+
+  def test_unsuccessful_store
+    credit_card = credit_card('4444333322221111', :month => 13)
+
+    assert response = @gateway.store(credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid EWAY_CARDEXPIRYMONTH', response.message
+  end
+
+  def test_successful_purchase_with_token
+    assert store = @gateway.store(@credit_card, @options)
+    assert_success store
+    assert response = @gateway.purchase(@amount, store.authorization, @options)
+    assert_success response
+    assert 'Transaction Approved', response.message
+  end
+
+  def test_unsuccessful_purchase_with_token
+    assert response = @gateway.purchase(@amount, 0, @options)
+    assert_failure response
+    assert 'V6040,V6021,V6022,V6101,V6102', response.message
+  end
+
+  def test_successful_purchase_with_token_and_billing_address
+    assert store = @gateway.store(@credit_card, @options_with_billing_address)
+    assert_success store
+    assert response = @gateway.purchase(@amount, store.authorization, @options_with_billing_address)
+    assert_success response
+    assert 'Transaction Approved', response.message
+  end
+
+  def test_successful_refund
+    assert purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+    assert response = @gateway.refund(@amount, purchase.params['TransactionID'], @options)
+    assert_success response
+  end
+
+  def test_unsuccessful_refund
+    assert response = @gateway.refund(@amount, 0, @options)
+    assert_failure response
+    assert 'S5010', response.message
+  end
+
+  def test_successful_update
+    assert store = @gateway.store(@credit_card, @options)
+    assert_success store
+
+    new_credit_card = credit_card('4444333322221111', :month => 3, :year => Time.now.year + 5)
+
+    assert response = @gateway.update(store.authorization, new_credit_card, @options)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal response.params['Customer']['CardDetails']['ExpiryMonth'], sprintf('%02d', new_credit_card.month)
+    assert_equal response.params['Customer']['CardDetails']['ExpiryYear'], new_credit_card.year.to_s[2,2]
+  end
+
+  def test_successful_update_with_billing_address
+    assert store = @gateway.store(@credit_card, @options_with_billing_address)
+    assert_success store
+
+    new_credit_card = credit_card('4444333322221111', :month => 3, :year => Time.now.year + 5)
+
+    assert response = @gateway.update(store.authorization, new_credit_card, @options_with_billing_address)
+    assert_success response
+    assert_equal 'Succeeded', response.message
+    assert_equal response.params['Customer']['CardDetails']['ExpiryMonth'], sprintf('%02d', new_credit_card.month)
+    assert_equal response.params['Customer']['CardDetails']['ExpiryYear'], new_credit_card.year.to_s[2,2]
+  end
+
+  def test_unsuccessful_update
+    assert response = @gateway.update(0, @credit_card, @options)
+    assert_failure response
+    assert_equal 'Invalid TokenCustomerID', response.message
+  end
+end

--- a/test/unit/gateways/eway_rapid31_test.rb
+++ b/test/unit/gateways/eway_rapid31_test.rb
@@ -1,0 +1,817 @@
+require 'test_helper'
+
+class EwayRapid31Test < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = EwayRapid31Gateway.new(
+                 :login => 'login',
+                 :password => 'password'
+               )
+
+    @credit_card = credit_card('4444333322221111')
+    @amount = 100
+
+    @options = {
+      :order_id => '1',
+      :billing_address => address,
+      :description => 'Store Purchase',
+      :email => 'jim.smith@example.com',
+      :ip => '127.0.0.1',
+      :transaction_type => 'MOTO'
+    }
+  end
+
+  def test_successful_purchase
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.purchase(@amount, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_purchase_request(100)) == JSON.parse(data)
+    end.respond_with(successful_purchase_response)
+
+    assert_equal '326898', @response.authorization
+    assert_success @response
+    assert @response.test?
+  end
+
+  def test_unsuccessful_purchase
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.purchase(@amount + 1, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_purchase_request(101)) == JSON.parse(data)
+    end.respond_with(failed_purchase_response)
+
+    assert_equal '', @response.authorization
+    assert_failure @response
+    assert @response.test?
+  end
+
+  def test_successful_store
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.store(@credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_store_request(:month => @credit_card.month)) == JSON.parse(data)
+    end.respond_with(successful_store_response)
+
+    assert_equal 915022769090, @response.authorization
+    assert_success @response
+    assert_nil @response.avs_result['code']
+    assert @response.test?
+  end
+
+  def test_unsuccessful_store
+    bad_credit_card = credit_card('4444333322221111', :month => 13)
+
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.store(bad_credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_store_request(:month => bad_credit_card.month)) == JSON.parse(data)
+    end.respond_with(failed_store_response)
+
+    assert_nil @response.authorization
+    assert_nil @response.avs_result['code']
+    assert_failure @response
+    assert @response.test?
+  end
+
+
+  def test_successful_purchase_with_token
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.purchase(@amount, 918260741894, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_purchase_with_token_request(918260741894)) == JSON.parse(data)
+    end.respond_with(successful_purchase_with_token_response)
+
+    assert_equal '511006', @response.authorization
+    assert_equal 918260741894, @response.params['Customer']['TokenCustomerID']
+    assert_success @response
+    assert @response.test?
+  end
+
+  def test_unsuccessful_purchase_with_token
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.purchase(@amount, 0, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_purchase_with_token_request(0)) == JSON.parse(data)
+    end.respond_with(failed_purchase_with_token_response)
+
+    assert 'V6040,V6021,V6022,V6101,V6102', @response.message
+    assert_failure @response
+    assert @response.test?
+  end
+
+  def test_successful_refund
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.refund(@amount, '10326714', @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_refund_request(10326714)) == JSON.parse(data)
+    end.respond_with(successful_refund_response)
+
+    assert_equal "607276", @response.authorization
+    assert_success @response
+    assert @response.test?
+  end
+
+  def test_unsuccessful_refund
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.refund(@amount, 0, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_refund_request(0)) == JSON.parse(data)
+    end.respond_with(failed_refund_response)
+
+    assert '', @response.authorization
+    assert 'S5010', @response.params['Errors']
+    assert_failure @response
+    assert @response.test?
+  end
+
+  def test_successful_update
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.update(915845997420, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_update_request(915845997420)) == JSON.parse(data)
+    end.respond_with(successful_refund_response)
+
+    assert_success @response
+    assert @response.test?
+  end
+
+  def test_unsuccessful_update
+    stub_comms(@gateway, :ssl_request) do
+      assert @response = @gateway.update(0, @credit_card, @options)
+    end.check_request do |method, endpoint, data, headers|
+      assert JSON.parse(expected_update_request(0)) == JSON.parse(data)
+    end.respond_with(failed_update_response)
+
+    assert_equal 'Invalid TokenCustomerID', @response.message
+    assert_failure @response
+    assert @response.test?
+  end
+
+  private
+
+  def successful_purchase_response
+    <<-JSON
+      {
+          "AuthorisationCode":"326898",
+          "ResponseCode":"00",
+          "ResponseMessage":"A2000",
+          "TransactionID":10324296,
+          "TransactionStatus":true,
+          "TransactionType":"MOTO",
+          "BeagleScore":0,
+          "Verification":{
+              "CVN":0,
+              "Address":0,
+              "Email":0,
+              "Mobile":0,
+              "Phone":0
+          },
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":null,
+              "Reference":"",
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":"",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Comments":"",
+              "Fax":"(555)555-6666",
+              "Url":""
+          },
+          "Payment":{
+              "TotalAmount":100,
+              "InvoiceNumber":"",
+              "InvoiceDescription":"Store Purchase",
+              "InvoiceReference":"1",
+              "CurrencyCode":"AUD"
+          },
+          "Errors":null
+      }
+    JSON
+  end
+
+  def failed_purchase_response
+    <<-JSON
+      {
+          "AuthorisationCode":"",
+          "ResponseCode":"01",
+          "ResponseMessage":"D4401",
+          "TransactionID":10324297,
+          "TransactionStatus":false,
+          "TransactionType":"MOTO",
+          "BeagleScore":0,
+          "Verification":{
+              "CVN":0,
+              "Address":0,
+              "Email":0,
+              "Mobile":0,
+              "Phone":0
+          },
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":null,
+              "Reference":"",
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":"",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Comments":"",
+              "Fax":"(555)555-6666",
+              "Url":""
+          },
+          "Payment":{
+              "TotalAmount":101,
+              "InvoiceNumber":"",
+              "InvoiceDescription":"Store Purchase",
+              "InvoiceReference":"1",
+              "CurrencyCode":"AUD"
+          },
+          "Errors":null
+      }
+    JSON
+  end
+
+  def expected_purchase_request(amount)
+    request = <<-JSON
+      {
+          "Payment":{
+              "InvoiceReference":"1",
+              "InvoiceDescription":"Store Purchase",
+              "TotalAmount":#{amount},
+              "CurrencyCode":"AUD"
+          },
+          "Customer":{
+              "CardDetails":{
+                  "Name":"Longbob Longsen",
+                  "Number":"4444333322221111",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "CVN":"123"
+              },
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "Title":"",
+              "CompanyName":"Widgets Inc",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Fax":"(555)555-6666",
+              "Email":"jim.smith@example.com"
+          },
+          "CustomerIP":"127.0.0.1",
+          "DeviceID":"ActiveMerchant",
+          "TransactionType":"MOTO"
+      }
+    JSON
+
+    request
+  end
+
+  def expected_store_request(options = {})
+    request = <<-JSON
+      {
+          "Customer":{
+              "CardDetails":{
+                  "Name":"Longbob Longsen",
+                  "Number":"4444333322221111",
+                  "ExpiryMonth":"#{sprintf('%02d', options[:month])}",
+                  "ExpiryYear":"15",
+                  "CVN":"123"
+              },
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "Title":"",
+              "CompanyName":"Widgets Inc",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Fax":"(555)555-6666",
+              "Email":"jim.smith@example.com"
+          }
+      }
+    JSON
+
+    request
+  end
+
+  def successful_store_response
+    <<-JSON
+      {
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":915022769090,
+              "Reference":"",
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":"",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Comments":"",
+              "Fax":"(555)555-6666",
+              "Url":""
+          },
+          "Errors":null
+      }
+    JSON
+  end
+
+  def failed_store_response
+    <<-JSON
+      {
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"13",
+                  "ExpiryYear":"15",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":null,
+              "Reference":null,
+              "Title":null,
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":null,
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":null,
+              "Comments":null,
+              "Fax":"(555)555-6666",
+              "Url":null
+          },
+          "Errors":"V6101"
+      }
+    JSON
+  end
+
+  def successful_refund_response
+    <<-JSON
+      {
+          "AuthorisationCode":"607276",
+          "ResponseCode":null,
+          "ResponseMessage":"A2000",
+          "TransactionID":10326715,
+          "TransactionStatus":true,
+          "Verification":null,
+          "Customer":{
+              "CardDetails":{
+                  "Number":null,
+                  "Name":null,
+                  "ExpiryMonth":null,
+                  "ExpiryYear":null,
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":null,
+              "Reference":null,
+              "Title":null,
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":null,
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":null,
+              "Comments":null,
+              "Fax":"(555)555-6666",
+              "Url":null
+          },
+          "Refund":{
+              "TransactionID":null,
+              "TotalAmount":100,
+              "InvoiceNumber":null,
+              "InvoiceDescription":null,
+              "InvoiceReference":null,
+              "CurrencyCode":null
+          },
+          "Errors":""
+      }
+    JSON
+  end
+
+  def expected_refund_request(trans_id)
+    request = <<-JSON
+      {
+          "Refund":{
+              "TransactionID":"#{trans_id}",
+              "InvoiceReference":"1",
+              "InvoiceDescription":"Store Purchase",
+              "TotalAmount":100,
+              "CurrencyCode":"AUD"
+          },
+          "Customer":{
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "Title":"",
+              "CompanyName":"Widgets Inc",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Fax":"(555)555-6666",
+              "Email":"jim.smith@example.com"
+          },
+          "CustomerIP":"127.0.0.1",
+          "DeviceID":"ActiveMerchant",
+          "TransactionType":"MOTO"
+      }
+    JSON
+
+    request
+  end
+
+  def failed_refund_response
+    <<-JSON
+      {
+          "AuthorisationCode":"",
+          "ResponseCode":null,
+          "ResponseMessage":"S5010",
+          "TransactionID":null,
+          "TransactionStatus":false,
+          "Verification":null,
+          "Customer":{
+              "CardDetails":{
+                  "Number":null,
+                  "Name":null,
+                  "ExpiryMonth":null,
+                  "ExpiryYear":null,
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":null,
+              "Reference":null,
+              "Title":null,
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":null,
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":null,
+              "Comments":null,
+              "Fax":"(555)555-6666",
+              "Url":null
+          },
+          "Refund":{
+              "TransactionID":null,
+              "TotalAmount":100,
+              "InvoiceNumber":null,
+              "InvoiceDescription":null,
+              "InvoiceReference":null,
+              "CurrencyCode":null
+          },
+          "Errors":"S5010"
+      }
+    JSON
+  end
+
+  def successful_purchase_with_token_response
+    <<-JSON
+      {
+          "AuthorisationCode":"511006",
+          "ResponseCode":"00",
+          "ResponseMessage":"A2000",
+          "TransactionID":10328337,
+          "TransactionStatus":true,
+          "TransactionType":"MOTO",
+          "BeagleScore":0,
+          "Verification":{
+              "CVN":0,
+              "Address":0,
+              "Email":0,
+              "Mobile":0,
+              "Phone":0
+          },
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "StartMonth":"",
+                  "StartYear":"",
+                  "IssueNumber":""
+              },
+              "TokenCustomerID":918260741894,
+              "Reference":"",
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":"",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Comments":"",
+              "Fax":"(555)555-6666",
+              "Url":""
+          },
+          "Payment":{
+              "TotalAmount":100,
+              "InvoiceNumber":"",
+              "InvoiceDescription":"Store Purchase",
+              "InvoiceReference":"1",
+              "CurrencyCode":"AUD"
+          },
+          "Errors":null
+      }
+    JSON
+  end
+
+  def expected_purchase_with_token_request(token)
+    request = <<-JSON
+      {
+          "Payment":{
+            "InvoiceReference":"1",
+            "InvoiceDescription":"Store Purchase",
+            "TotalAmount":100,
+            "CurrencyCode":"AUD"
+          },
+          "Customer":{
+            "TokenCustomerID":"#{token}",
+            "FirstName":"Jim",
+            "LastName":"Smith",
+            "Title":"",
+            "CompanyName":"Widgets Inc",
+            "Street1":"1234 My Street",
+            "Street2":"Apt 1",
+            "City":"Ottawa",
+            "State":"ON",
+            "PostalCode":"K1C2N6",
+            "Country":"ca",
+            "Phone":"(555)555-5555",
+            "Mobile":"",
+            "Fax":"(555)555-6666",
+            "Email":"jim.smith@example.com"
+          },
+          "CustomerIP":"127.0.0.1",
+          "DeviceID":"ActiveMerchant",
+          "TransactionType":"MOTO"
+      }
+    JSON
+
+    request
+  end
+
+  def failed_purchase_with_token_response
+    <<-JSON
+      {
+          "AuthorisationCode":null,
+          "ResponseCode":null,
+          "ResponseMessage":null,
+          "TransactionID":null,
+          "TransactionStatus":null,
+          "TransactionType":"MOTO",
+          "BeagleScore":null,
+          "Verification":null,
+          "Customer":{
+              "CardDetails":{
+                  "Number":null,
+                  "Name":null,
+                  "ExpiryMonth":null,
+                  "ExpiryYear":null,
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":0,
+              "Reference":null,
+              "Title":null,
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":null,
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":null,
+              "Comments":null,
+              "Fax":"(555)555-6666",
+              "Url":null
+          },
+          "Payment":{
+              "TotalAmount":100,
+              "InvoiceNumber":null,
+              "InvoiceDescription":"Store Purchase",
+              "InvoiceReference":"1",
+              "CurrencyCode":"AUD"
+          },
+          "Errors":"V6040,V6021,V6022,V6101,V6102"
+      }
+    JSON
+  end
+
+  def successful_update_response
+    <<-JSON
+      {
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"03",
+                  "ExpiryYear":"18",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":915845997420,
+              "Reference":"",
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":"",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Comments":"",
+              "Fax":"(555)555-6666",
+              "Url":""
+          },
+          "Errors":null
+      }
+    JSON
+  end
+
+  def expected_update_request(token)
+    request = <<-JSON
+      {
+          "Customer":{
+              "TokenCustomerID":"#{token}",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "Title":"",
+              "CompanyName":"Widgets Inc",
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Phone":"(555)555-5555",
+              "Mobile":"",
+              "Fax":"(555)555-6666",
+              "Email":"jim.smith@example.com",
+              "CardDetails":{
+                  "Name":"Longbob Longsen",
+                  "Number":"4444333322221111",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "CVN":"123"
+              }
+          },
+          "CustomerIP":"127.0.0.1",
+          "DeviceID":"ActiveMerchant",
+          "TransactionType":"MOTO"
+      }
+    JSON
+
+    request
+  end
+
+  def failed_update_response
+    <<-JSON
+      {
+          "Customer":{
+              "CardDetails":{
+                  "Number":"444433XXXXXX1111",
+                  "Name":"Longbob Longsen",
+                  "ExpiryMonth":"09",
+                  "ExpiryYear":"15",
+                  "StartMonth":null,
+                  "StartYear":null,
+                  "IssueNumber":null
+              },
+              "TokenCustomerID":0,
+              "Reference":null,
+              "Title":"Mr.",
+              "FirstName":"Jim",
+              "LastName":"Smith",
+              "CompanyName":"Widgets Inc",
+              "JobDescription":null,
+              "Street1":"1234 My Street",
+              "Street2":"Apt 1",
+              "City":"Ottawa",
+              "State":"ON",
+              "PostalCode":"K1C2N6",
+              "Country":"ca",
+              "Email":"jim.smith@example.com",
+              "Phone":"(555)555-5555",
+              "Mobile":null,
+              "Comments":null,
+              "Fax":"(555)555-6666",
+              "Url":null
+          },
+          "Errors":"V6040"
+      }
+    JSON
+  end
+end


### PR DESCRIPTION
This cherry-picks 92bf08273a1b55fa8d519a9e63537fec984b6a6c to to re-add eWAY Rapid 3.1.

Thanks to @moklett who had a major part in helping me put this together.

We don't want to require billing_address for #purchase because it
doesn't require one itself in the API.

Added tests to remote for purchases / etc with and without billing
address.

During all of this we also discovered that #store requires a billing
address with at LEAST country and name. From the eWAY folks this is for
legacy API reasons.