### PR TITLE
Always send amount and currency to Quickpay store card

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -6,7 +6,7 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class QuickpayV4to7Gateway < Gateway
       include QuickpayCommon
-      self.live_url = self.test_url = 'https://secure.quickpay.dk/api'    
+      self.live_url = self.test_url = 'https://secure.quickpay.dk/api'
       APPROVED = '000'
 
       # The login is the QuickpayId
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_creditcard(post, creditcard, options)
-        add_amount(post, 0, options) if @protocol >= 7
+        add_amount(post, 0, options)
         add_invoice(post, options)
         add_description(post, options)
         add_fraud_parameters(post, options)


### PR DESCRIPTION
This removes the condition `if @protocol >= 7` so the amount and the currency will be sent to `:subscribe` requests made over the v3 protocol.

The reason for this is a change on the part of Quickpay now requiring this information to be present.