### PR TITLE
Add amount and currency to md5 check fields

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_common.rb
@@ -13,7 +13,7 @@ module QuickpayCommon
 
       :refund    => %w(protocol msgtype merchant amount transaction),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
+      :subscribe => %w(protocol msgtype merchant ordernumber amount currency cardnumber
                        expirationdate cvd cardtypelock description testmode),
 
       :recurring => %w(protocol msgtype merchant ordernumber amount
@@ -38,7 +38,7 @@ module QuickpayCommon
 
       :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
+      :subscribe => %w(protocol msgtype merchant ordernumber amount currency cardnumber
                        expirationdate cvd cardtypelock description testmode
                        fraud_remote_addr fraud_http_accept fraud_http_accept_language
                        fraud_http_accept_encoding fraud_http_accept_charset
@@ -66,7 +66,7 @@ module QuickpayCommon
 
       :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
+      :subscribe => %w(protocol msgtype merchant ordernumber amount currency cardnumber
                        expirationdate cvd cardtypelock description testmode
                        fraud_remote_addr fraud_http_accept fraud_http_accept_language
                        fraud_http_accept_encoding fraud_http_accept_charset
@@ -95,7 +95,7 @@ module QuickpayCommon
 
       :refund    => %w(protocol msgtype merchant amount transaction apikey),
 
-      :subscribe => %w(protocol msgtype merchant ordernumber cardnumber
+      :subscribe => %w(protocol msgtype merchant ordernumber amount currency cardnumber
                        expirationdate cvd cardtypelock description testmode
                        fraud_remote_addr fraud_http_accept fraud_http_accept_language
                        fraud_http_accept_encoding fraud_http_accept_charset
@@ -138,9 +138,9 @@ module QuickpayCommon
 
       :chstatus  => %w(protocol msgtype merchant apikey)
     },
-    
+
     10 => {
-      :authorize => %w(mobile_number acquirer autofee customer_id extras 
+      :authorize => %w(mobile_number acquirer autofee customer_id extras
                        zero_auth customer_ip),
       :capture   => %w( extras ),
       :cancel    => %w( extras ),
@@ -150,7 +150,7 @@ module QuickpayCommon
       :recurring => %w(auto_capture autofee zero_auth)
     }
   }
-  
+
   RESPONSE_CODES = {
     200 => 'OK',
     201 => 'Created',
@@ -165,19 +165,19 @@ module QuickpayCommon
     409 => 'Conflict',
     500 => 'Internal Server Error'
   }
-  
+
   def self.included(base)
     base.default_currency = 'DKK'
     base.money_format = :cents
-    
-    base.supported_cardtypes = [:dankort, :forbrugsforeningen, :visa, :master, 
+
+    base.supported_cardtypes = [:dankort, :forbrugsforeningen, :visa, :master,
                                 :american_express, :diners_club, :jcb, :maestro]
     base.supported_countries = ['DE', 'DK', 'ES', 'FI', 'FR', 'FO', 'GB', 'IS', 'NO', 'SE']
     base.homepage_url = 'http://quickpay.net/'
     base.display_name = 'QuickPay'
 
   end
-    
+
   def expdate(credit_card)
     year  = format(credit_card.year, :two_digits)
     month = format(credit_card.month, :two_digits)


### PR DESCRIPTION
The latest PR (https://github.com/chargify/active_merchant/pull/39) added amount and currency to `:subscribe` requests. That caused a new error due to MD5 checks not including these fields. This PR fixes this.