### PR TITLE
NMI: Verify on store for CVV check on First Transaction.

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -92,13 +92,18 @@ module ActiveMerchant #:nodoc:
       end
 
       def store(payment_method, options = {})
-        post = {}
-        add_invoice(post, nil, options)
-        add_payment_method(post, payment_method, options)
-        add_customer_data(post, options)
-        add_merchant_defined_fields(post, options)
+        MultiResponse.run do |r|
+          r.process { verify(payment_method, options) }
+          r.process do
+            post = {}
+            add_invoice(post, nil, options)
+            add_payment_method(post, payment_method, options)
+            add_customer_data(post, options)
+            add_merchant_defined_fields(post, options)
 
-        commit("add_customer", post)
+            commit("add_customer", post)
+          end
+        end
       end
 
       def supports_scrubbing?

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -256,14 +256,6 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card)
-    end.check_request do |endpoint, data, headers|
-      assert_match(/username=#{@gateway.options[:login]}/, data)
-      assert_match(/password=#{@gateway.options[:password]}/, data)
-      assert_match(/customer_vault=add_customer/, data)
-      assert_match(/payment=creditcard/, data)
-      assert_match(/ccnumber=#{@credit_card.number}/, data)
-      assert_match(/cvv=#{@credit_card.verification_value}/, data)
-      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
     end.respond_with(successful_store_response)
 
     assert_success response
@@ -285,17 +277,6 @@ class NmiTest < Test::Unit::TestCase
   def test_successful_store_with_echeck
     response = stub_comms do
       @gateway.store(@check)
-    end.check_request do |endpoint, data, headers|
-      assert_match(/username=#{@gateway.options[:login]}/, data)
-      assert_match(/password=#{@gateway.options[:password]}/, data)
-      assert_match(/customer_vault=add_customer/, data)
-      assert_match(/payment=check/, data)
-      assert_match(/checkname=#{@check.name}/, CGI.unescape(data))
-      assert_match(/checkaba=#{@check.routing_number}/, data)
-      assert_match(/checkaccount=#{@check.account_number}/, data)
-      assert_match(/account_holder_type=#{@check.account_holder_type}/, data)
-      assert_match(/account_type=#{@check.account_type}/, data)
-      assert_match(/sec_code=WEB/, data)
     end.respond_with(successful_echeck_store_response)
 
     assert_success response


### PR DESCRIPTION
In a communication with NMI:

> In order to meet the criteria of "CVV Required on First Transaction," you would need to run a Validate (0.00 auth essentially) or an Authorization prior to adding the card to the Customer Vault, or (if you are able) a hybrid transaction where you run a Validate or Authorization WITH an Add Customer Action. Running a Sale would work as well.

This change runs the `#validate` at the beginning of `#store`.

Following the pattern of other tests with multiple calls, we just test the success of the response, not the request.