### PR TITLE
CyberSource: Translate REJECT with reason_code 100 as Failure

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -702,7 +702,12 @@ module ActiveMerchant #:nodoc:
         end
 
         success = response[:decision] == "ACCEPT"
-        message = @@response_codes[('r' + response[:reasonCode]).to_sym] rescue response[:message]
+
+        response_code = ('r' + response[:reasonCode]).to_sym
+        # CyberSource sometimes returns a REJECT with reason_code 100.
+        # Set message to 'Failure' instead of 'Successful transaction' in that case.
+        message = (!success && response_code == :r100) ? "Failure" : @@response_codes[response_code] rescue response[:message]
+
         authorization = success ? [ options[:order_id], response[:requestID], response[:requestToken] ].compact.join(";") : nil
 
         Response.new(success, message, response,

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -703,7 +703,7 @@ module ActiveMerchant #:nodoc:
 
         success = response[:decision] == "ACCEPT"
 
-        response_code = ('r' + response[:reasonCode]).to_sym
+        response_code = ('r' + response.fetch(:reasonCode,'')).to_sym
         # CyberSource sometimes returns a REJECT with reason_code 100.
         # Set message to 'Failure' instead of 'Successful transaction' in that case.
         message = (!success && response_code == :r100) ? "Failure" : @@response_codes[response_code] rescue response[:message]

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -62,6 +62,15 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_unsuccessful_purchase_with_reason_code_100
+    @gateway.expects(:ssl_post).returns(unsuccessful_purchase_with_reason_code_100_response)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_equal 'Failure', response.message
+    assert_failure response
+    assert response.test?
+  end
+
   def test_purchase_includes_customer_ip
     customer_ip_regexp = /<ipAddress>#{@customer_ip}<\//
     @gateway.expects(:ssl_post).
@@ -452,6 +461,14 @@ class CyberSourceTest < Test::Unit::TestCase
 <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690"><wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26"><c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode><c:requestID>2004333231260008401927</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>123456</c:authorizationCode><c:avsCode>Y</c:avsCode><c:avsCodeRaw>Y</c:avsCodeRaw><c:cvCode>M</c:cvCode><c:cvCodeRaw>M</c:cvCodeRaw><c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime><c:processorResponse>00</c:processorResponse><c:authFactorCode>U</c:authFactorCode></c:ccAuthReply></c:replyMessage></soap:Body></soap:Envelope>
     XML
   end
+
+    def unsuccessful_purchase_with_reason_code_100_response
+      <<-XML
+  <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Header>
+  <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-2636690"><wsu:Created>2008-01-15T21:42:03.343Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.26"><c:merchantReferenceCode>b0a6cf9aa07f1a8495f89c364bbd6a9a</c:merchantReferenceCode><c:requestID>2004333231260008401927</c:requestID><c:decision>REJECT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>Afvvj7Ke2Fmsbq0wHFE2sM6R4GAptYZ0jwPSA+R9PhkyhFTb0KRjoE4+ynthZrG6tMBwjAtT</c:requestToken><c:purchaseTotals><c:currency>USD</c:currency></c:purchaseTotals><c:ccAuthReply><c:reasonCode>100</c:reasonCode><c:amount>1.00</c:amount><c:authorizationCode>123456</c:authorizationCode><c:avsCode>I</c:avsCode><c:avsCodeRaw>11</c:avsCodeRaw><c:cvCode>M</c:cvCode><c:cvCodeRaw>M</c:cvCodeRaw><c:authorizedDateTime>2008-01-15T21:42:03Z</c:authorizedDateTime><c:processorResponse>00</c:processorResponse><c:authFactorCode>U</c:authFactorCode></c:ccAuthReply></c:replyMessage></soap:Body></soap:Envelope>
+      XML
+    end
 
   def successful_authorization_response
     <<-XML


### PR DESCRIPTION
CyberSource sometimes sends a response that has reason_code 100 (meaning Successful transaction) but the overall decision was REJECT.

It is confusing to see a success message alongside a failure, so in this one case, we will override the translation for the code.