### PR TITLE
Vantiv (Litle): Update sandbox url for testing

### DIFF
--- a/lib/active_merchant/billing/gateways/litle.rb
+++ b/lib/active_merchant/billing/gateways/litle.rb
@@ -5,7 +5,7 @@ module ActiveMerchant #:nodoc:
     class LitleGateway < Gateway
       SCHEMA_VERSION = '9.4'
 
-      self.test_url = 'https://www.testlitle.com/sandbox/communicator/online'
+      self.test_url = 'https://www.testvantivcnp.com/sandbox/communicator/online'
       self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'
 
       self.supported_countries = ['US']


### PR DESCRIPTION
Previously the URL for live transactions was updated, however the test url wasn't.

This updates the sandbox url based on the documentation in  https://developer.vantiv.com/docs/DOC-1375