### PR TITLE
Cybersource:  Adds ability to have stored ACH purchases.

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -709,7 +709,7 @@ module ActiveMerchant #:nodoc:
         # Set message to 'Failure' instead of 'Successful transaction' in that case.
         message = (!success && response_code == :r100) ? "Failure" : @@response_codes[response_code] rescue response[:message]
 
-        # if a soupFault is thrown there wont be a reasonCode
+        # if a <soap::Fault> is in the return xml there wont be a reasonCode
         if !success && @@response_codes[response_code].nil?
           message = response[:message]
         end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -108,6 +108,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_equal 'One or more fields contains invalid data', auth_reversal.message
   end
 
+  # Requires setup on cybersource side to work
   def test_successful_tax_calculation
     assert response = @gateway.calculate_tax(@credit_card, @options)
     assert_equal 'Successful transaction', response.message
@@ -345,6 +346,46 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
 
     assert response = @gateway.retrieve(response.authorization, :order_id => generate_unique_id)
     assert response.success?
+    assert response.test?
+  end
+
+  def test_successful_stored_check_request
+       check_details = {
+      :first_name => 'Sharona',
+      :last_name => 'Fleming' ,
+      :bank_name =>  'First Bank of New Jersery',
+      :routing_number => '121042882',
+      :account_number => '4100',
+      :account_holder_type => 'personal',
+      :account_type => 'checking',
+    }
+
+    the_check = check(check_details)
+
+    subscription_options = {
+      :order_id => generate_unique_id,
+      :billing_address => {
+        :name => "Sharona Fleming",
+        :address1 => "123 Main Street",
+        :address2 => "",
+        :city => "Princeton",
+        :state => "NJ",
+        :zip => "08540",
+        :country => "US"
+      },
+      :email => "s@fleming.com",
+      :currency => "USD",
+    }
+
+    purchase_options = {
+      :order_id => generate_unique_id,
+      :description => "Sharona Fleming - Pro: Renewal payment",
+      :currency => "USD",
+      :source_type => "check"
+    }
+
+    assert_success(response = @gateway.store(the_check, subscription_options))
+    assert_success(@gateway.purchase(@amount, response.authorization, purchase_options))
     assert response.test?
   end
 end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -350,7 +350,7 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   def test_successful_stored_check_request
-       check_details = {
+    check_details = {
       :first_name => 'Sharona',
       :last_name => 'Fleming' ,
       :bank_name =>  'First Bank of New Jersery',

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -404,6 +404,48 @@ class CyberSourceTest < Test::Unit::TestCase
     assert_instance_of TrueClass, @gateway.supports_network_tokenization?
   end
 
+  def test_successful_stored_check_request
+    @gateway.stubs(:ssl_post).returns(successful_store_check_response, successful_stored_check_purchase_response)
+
+    check_details = {
+      :first_name => 'Sharona',
+      :last_name => 'Fleming' ,
+      :bank_name =>  'First Bank of New Jersery',
+      :routing_number => '121042882',
+      :account_number => '4100',
+      :account_holder_type => 'personal',
+      :account_type => 'checking',
+    }
+
+    the_check = check(check_details)
+
+    subscription_options = {
+      :order_id => generate_unique_id,
+      :billing_address => {
+        :name => "Sharona Fleming",
+        :address1 => "123 Main Street",
+        :address2 => "",
+        :city => "Princeton",
+        :state => "NJ",
+        :zip => "08540",
+        :country => "US"
+      },
+      :email => "s@fleming.com",
+      :currency => "USD",
+     }
+
+    purchase_options = {
+      :order_id => generate_unique_id,
+      :description => "Sharona Fleming - Pro: Renewal payment",
+      :currency => "USD",
+      :source_type => "check"
+    }
+
+    assert_success(response = @gateway.store(the_check, subscription_options))
+    assert_success(@gateway.purchase(@amount, response.authorization, purchase_options))
+    assert response.test?
+  end
+
   private
 
   def pre_scrubbed
@@ -553,6 +595,86 @@ class CyberSourceTest < Test::Unit::TestCase
 <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
 <soap:Header>
 <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"><wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-190204278"><wsu:Created>2013-05-13T13:52:57.159Z</wsu:Created></wsu:Timestamp></wsse:Security></soap:Header><soap:Body><c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.69"><c:merchantReferenceCode>6427013</c:merchantReferenceCode><c:requestID>3684531771310176056442</c:requestID><c:decision>ACCEPT</c:decision><c:reasonCode>100</c:reasonCode><c:requestToken>AhijbwSRj3pM2QqPs2j0Ip+xoJXIsAMPYZNJMq6PSbs5ATAA6z42</c:requestToken><c:pinlessDebitValidateReply><c:reasonCode>100</c:reasonCode><c:requestDateTime>2013-05-13T13:52:57Z</c:requestDateTime><c:status>Y</c:status></c:pinlessDebitValidateReply></c:replyMessage></soap:Body></soap:Envelope>
+    XML
+  end
+
+  def successful_store_check_response
+    <<-XML
+   <?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Header>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-1573766200">
+                <wsu:Created>2018-12-07T20:25:07.788Z</wsu:Created>
+            </wsu:Timestamp>
+        </wsse:Security>
+    </soap:Header>
+    <soap:Body>
+        <c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.121">
+            <c:merchantReferenceCode>201812072025073053028051</c:merchantReferenceCode>
+            <c:requestID>5442143076016152204007</c:requestID>
+            <c:decision>ACCEPT</c:decision>
+            <c:reasonCode>100</c:reasonCode>
+            <c:requestToken>Ahj/7wSTJwToJe1KaVLnESDdq1ZNHDVw2nyYbJjZiqNPtB8oyAVGn2g+UZaQAglYZNJMt0gOG+xgTkycE6CXtSmlS5wAIz6I</c:requestToken>
+            <c:purchaseTotals>
+                <c:currency>USD</c:currency>
+            </c:purchaseTotals>
+            <c:ccAuthReply>
+                <c:reasonCode>100</c:reasonCode>
+                <c:amount>0.00</c:amount>
+                <c:authorizationCode>888888</c:authorizationCode>
+                <c:avsCode>X</c:avsCode>
+                <c:avsCodeRaw>I1</c:avsCodeRaw>
+                <c:authorizedDateTime>2018-12-07T20:25:07Z</c:authorizedDateTime>
+                <c:processorResponse>100</c:processorResponse>
+                <c:reconciliationID>755248586OIC21YE</c:reconciliationID>
+                <c:paymentNetworkTransactionID>123456789000000</c:paymentNetworkTransactionID>
+            </c:ccAuthReply>
+            <c:paySubscriptionCreateReply>
+                <c:reasonCode>100</c:reasonCode>
+                <c:subscriptionID>5442143076016152204007</c:subscriptionID>
+            </c:paySubscriptionCreateReply>
+        </c:replyMessage>
+    </soap:Body>
+</soap:Envelope>
+    XML
+  end
+
+  def successful_stored_check_purchase_response
+    <<-XML
+     <?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Header>
+        <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+            <wsu:Timestamp xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Timestamp-419233212">
+                <wsu:Created>2018-12-07T20:44:07.393Z</wsu:Created>
+            </wsu:Timestamp>
+        </wsse:Security>
+    </soap:Header>
+    <soap:Body>
+        <c:replyMessage xmlns:c="urn:schemas-cybersource-com:transaction-data-1.121">
+            <c:merchantReferenceCode>ham-2018120720271312</c:merchantReferenceCode>
+            <c:requestID>5442154471776379104012</c:requestID>
+            <c:decision>ACCEPT</c:decision>
+            <c:reasonCode>100</c:reasonCode>
+            <c:requestToken>Ahjr7wSTJwUQok96rmsMEVGn2hBo+KNPtCDR80gdOIQSsMmkmW6QHDfYgCyZOCiFEnvVc1hgrDpT</c:requestToken>
+            <c:purchaseTotals>
+                <c:currency>USD</c:currency>
+            </c:purchaseTotals>
+            <c:ecDebitReply>
+                <c:reasonCode>100</c:reasonCode>
+                <c:settlementMethod>B</c:settlementMethod>
+                <c:requestDateTime>2018-12-07T20:44:07Z</c:requestDateTime>
+                <c:amount>100.00</c:amount>
+                <c:verificationLevel>1</c:verificationLevel>
+                <c:reconciliationID>OL8X72FGJOIBH86I</c:reconciliationID>
+                <c:processorResponse>123456</c:processorResponse>
+                <c:avsCode>1</c:avsCode>
+                <c:ownerMerchantID>chargify</c:ownerMerchantID>
+            </c:ecDebitReply>
+        </c:replyMessage>
+    </soap:Body>
+</soap:Envelope>
     XML
   end
 end


### PR DESCRIPTION
It was noticed that the cybersource gateway was interpreting all transactions as stored credit cards, when it was possible to encounter stored ACH payment sources.

This change simply passes in what kind of transaction it is, 'check' or 'credit_card', whenever a tokenized operation is performed (Because if all you have is a token, you cant tell what kind of operation it is).  This information is included in the options hash under the key  ```:source_type```.     

The stubbed xml responses for store and purchase where taken directly from the chargify store and purchase raw gateway logs.  

The soapfault message change was done to fix a broken test, not sure how long it has been broken, but its not related at all to this change.

There is a remote tax test that fails, but this appears to be related to configuration in the backend merchant account and is not relevant.