### PR TITLE
GoCardless: add danish_identity_number and swedish_identity_number to customer attributes

### DIFF
--- a/lib/active_merchant/billing/gateways/go_cardless.rb
+++ b/lib/active_merchant/billing/gateways/go_cardless.rb
@@ -168,7 +168,9 @@ module ActiveMerchant #:nodoc:
             "email": customer_attributes['email'],
             "given_name": customer_attributes['first_name'],
             "family_name": customer_attributes['last_name'],
-            "phone_number": customer_attributes['phone']
+            "phone_number": customer_attributes['phone'],
+            "danish_identity_number": customer_attributes['danish_identity_number'],
+            "swedish_identity_number": customer_attributes['swedish_identity_number']
           }
         }
         if options[:billing_address]


### PR DESCRIPTION
It adds `danish_identity_number` and `swedish_identity_number` to customer attributes (these are required for Sweden and New Zealand GoCardless schemes). 