### PR TITLE
[internal] Adds NMI Stored Credentials support

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -33,6 +33,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_merchant_defined_fields(post, options)
+        add_stored_credentials_options(post, options)
 
         commit("sale", post)
       end
@@ -43,6 +44,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_merchant_defined_fields(post, options)
+        add_stored_credentials_options(post, options)
 
         commit("auth", post)
       end
@@ -78,6 +80,7 @@ module ActiveMerchant #:nodoc:
         add_invoice(post, amount, options)
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
+        add_stored_credentials_options(post, options)
 
         commit("credit", post)
       end
@@ -87,6 +90,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_merchant_defined_fields(post, options)
+        add_stored_credentials_options(post, options)
 
         commit("validate", post)
       end
@@ -97,6 +101,7 @@ module ActiveMerchant #:nodoc:
         add_payment_method(post, payment_method, options)
         add_customer_data(post, options)
         add_merchant_defined_fields(post, options)
+        add_stored_credentials_options(post, options)
 
         commit("add_customer", post)
       end
@@ -191,6 +196,24 @@ module ActiveMerchant #:nodoc:
       def add_payment_type(post, authorization)
         _, payment_type = split_authorization(authorization)
         post[:payment] = payment_type if payment_type
+      end
+
+      def add_stored_credentials_options(post, options)
+        return unless (stored_credential = options[:stored_credential])
+
+        if stored_credential[:initial_transaction]
+          post[:stored_credential_indicator] = 'stored'
+        else
+          post[:stored_credential_indicator] = 'used'
+        end
+
+        if stored_credential[:initiator] == 'merchant'
+          post[:initiated_by] = 'merchant'
+        else
+          post[:initiated_by] = 'customer'
+        end
+
+        post[:initial_transaction_id] = stored_credential[:network_transaction_id]
       end
 
       def exp_date(payment_method)

--- a/lib/active_merchant/network_connection_retries.rb
+++ b/lib/active_merchant/network_connection_retries.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 module ActiveMerchant
   module NetworkConnectionRetries
     DEFAULT_RETRIES = 3

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -284,6 +284,6 @@ class RemoteNmiTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, vault_id, @options)
 
     assert_failure response
-    assert_match /Invalid Initial Transaction ID/, response.message
+    assert_match(/Invalid Initial Transaction ID/, response.message)
   end
 end

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -234,4 +234,56 @@ class RemoteNmiTest < Test::Unit::TestCase
     # "password=password is filtered, but can't be tested b/c of key match"
     # assert_scrubbed(@gateway.options[:password], clean_transcript)
   end
+
+  def test_successful_store_and_purchase_with_stored_credentials
+    @options.merge!(stored_credential: {
+      initial_transaction: true,
+      recurring: nil,
+      initiator: 'cardholder',
+      network_transaction_id: nil
+    })
+    vault_id = @gateway.store(@credit_card, @options).params["customer_vault_id"]
+    purchase = @gateway.purchase(@amount, vault_id, @options)
+    transaction_id = purchase.params["transactionid"]
+    assert_success purchase
+    assert_equal "Succeeded", purchase.message
+
+    # Second request as MIT
+    @options.merge!(stored_credential: {
+      initial_transaction: false,
+      recurring: true,
+      initiator: 'merchant',
+      network_transaction_id: transaction_id
+    })
+    purchase = @gateway.purchase(@amount, vault_id, @options)
+    purchase.params["transactionid"]
+
+    assert_success purchase
+    assert_equal "Succeeded", purchase.message
+  end
+
+  def test_failed_store_and_purchase_with_stored_credentials
+    @options.merge!(stored_credential: {
+      initial_transaction: true,
+      recurring: nil,
+      initiator: 'cardholder',
+      network_transaction_id: nil
+    })
+    vault_id = @gateway.store(@credit_card, @options).params["customer_vault_id"]
+    purchase = @gateway.purchase(@amount, vault_id, @options)
+    assert_success purchase
+    assert_equal "Succeeded", purchase.message
+
+    # Second request as MIT
+    @options.merge!(stored_credential: {
+      initial_transaction: false,
+      recurring: true,
+      initiator: 'merchant',
+      network_transaction_id: '10202-fake'
+    })
+    response = @gateway.purchase(@amount, vault_id, @options)
+
+    assert_failure response
+    assert_match /Invalid Initial Transaction ID/, response.message
+  end
 end

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -429,7 +429,7 @@ class NmiTest < Test::Unit::TestCase
 
     assert_failure response
     assert response.test?
-    assert_match /Invalid Initial Transaction ID/, response.message
+    assert_match(/Invalid Initial Transaction ID/, response.message)
   end
 
 

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -363,6 +363,76 @@ class NmiTest < Test::Unit::TestCase
     end
   end
 
+  def test_successful_purchase_with_stored_credentials_cit
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: true,
+        recurring: nil,
+        initiator: 'cardholder',
+        network_transaction_id: nil
+      }
+    }
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/initiated_by=customer/, data)
+      assert_match(/initial_transaction_id=/, data)
+      assert_match(/stored_credential_indicator=stored/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal "2762757839", response.params['transactionid']
+  end
+
+  def test_successful_purchase_with_stored_credentials_mit
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        recurring: true,
+        initiator: 'merchant',
+        network_transaction_id: '2762797441'
+      }
+    }
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/initial_transaction_id=2762797441/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal "2762757839", response.params['transactionid']
+  end
+
+  def test_failed_purchase_with_stored_credentials_mit
+    stored_credential = {
+      stored_credential: {
+        initial_transaction: false,
+        recurring: true,
+        initiator: 'merchant',
+        network_transaction_id: '2762797441'
+      }
+    }
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge(stored_credential))
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/initiated_by=merchant/, data)
+      assert_match(/initial_transaction_id=2762797441/, data)
+      assert_match(/stored_credential_indicator=used/, data)
+    end.respond_with(failed_mit_purchase_response)
+
+    assert_failure response
+    assert response.test?
+    assert_match /Invalid Initial Transaction ID/, response.message
+  end
+
+
   private
 
   def successful_purchase_response
@@ -457,5 +527,9 @@ class NmiTest < Test::Unit::TestCase
       amount=1.00&orderid=e88df316d8ba3c8c6b98aa93b78facc0&orderdescription=Store+purchase&currency=USD&payment=check&checkname=Jim+Smith&checkaba=[FILTERED]&checkaccount=[FILTERED]&account_holder_type=personal&account_type=checking&sec_code=WEB&email=&ipaddress=&company=Widgets+Inc&address1=456+My+Street&address2=Apt+1&city=Ottawa&state=ON&country=CA&zip=K1C2N6&phone=%28555%29555-5555&type=sale&username=demo&password=[FILTERED]
       response=1&responsetext=SUCCESS&authcode=123456&transactionid=2767467157&avsresponse=&cvvresponse=&orderid=e88df316d8ba3c8c6b98aa93b78facc0&type=sale&response_code=100
     )
+  end
+
+  def failed_mit_purchase_response
+    'response=3&responsetext=Invalid Initial Transaction ID REFID:1197003826&authcode=&transactionid=&avsresponse=&cvvresponse=&orderid=7d9e38cff13df87aef9d26c7536cebe8&type=sale&response_code=300'
   end
 end


### PR DESCRIPTION
**User Story:** As a merchant, I would like to be able to send all of the details, fields, & data required by Visa & Mastercard to be compliant and avoid high transaction failure rates.

### How?
Using this commit https://github.com/activemerchant/active_merchant/commit/b12da5a8b1737f91b8f570512582c1f79904922f as the introduction to the normalized stored credential options, I have added NMI specific fields to the request.

```
The hash takes the following structure:

{
  stored_credential: {
    inital_transaction: Boolean, # either true or false
    recurring: Boolean, # either true or false
    initiator: String, # either "merchant" or "cardholder"
    network_transaction_id: String # returned card network transaction id
  }
}
```
[NMI Docs](https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#transaction_variables)

### Tests
```
# bundle exec ruby -Itest test/unit/gateways/nmi_test.rb                                                                                
Loaded suite test/unit/gateways/nmi_test
Started
..............................
Finished in 0.020793 seconds.
------------------------------------------------------------------------------------------------------
30 tests, 216 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```
```
# bundle exec ruby -Itest test/remote/gateways/remote_nmi_test.rb
Loaded suite test/remote/gateways/remote_nmi_test
Started
.................F.......F.....
Finished in 50.665401 seconds.
------------------------------------------------------------------------------------------------------
31 tests, 97 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
93.5484% passed
```
Two remote tests failed because `Credits are not enabled`, but we do not support credits in our code.
