### PR TITLE
Add 3D secure (cherry pick 48440c)

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -6,8 +6,8 @@ rescue LoadError
   raise "Could not load the braintree gem.  Use `gem install braintree` to install it."
 end
 
-unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 4
-  raise "Need braintree gem >= 2.4.0. Run `gem install braintree --version '~>2.4'` to get the correct version."
+unless Braintree::Version::Major == 2 && Braintree::Version::Minor >= 78
+  raise "Need braintree gem >= 2.78.0. Run `gem install braintree --version '~>2.78'` to get the correct version."
 end
 
 module ActiveMerchant #:nodoc:
@@ -665,6 +665,14 @@ module ActiveMerchant #:nodoc:
             name: options[:descriptor_name],
             phone: options[:descriptor_phone],
             url: options[:descriptor_url]
+          }
+        end
+
+        if options[:three_d_secure]
+          parameters[:three_d_secure_pass_thru] = {
+            cavv: options[:three_d_secure][:cavv],
+            eci_flag: options[:three_d_secure][:eci],
+            xid: options[:three_d_secure][:xid],
           }
         end
 

--- a/test/remote/gateways/remote_braintree_orange_test.rb
+++ b/test/remote/gateways/remote_braintree_orange_test.rb
@@ -142,6 +142,12 @@ class RemoteBraintreeOrangeTest < Test::Unit::TestCase
     assert  response.message.match(/Invalid Transaction ID \/ Object ID specified:/)
   end
 
+  def test_authorize_with_three_d_secure_pass_thru
+    assert auth = @gateway.authorize(@amount, @credit_card, @options.merge(eci: "05", xid: "xid", cavv: "cavv"))
+    assert_success auth
+    assert_equal 'This transaction has been approved', auth.message
+  end
+
   def test_successful_verify
     assert response = @gateway.verify(@credit_card, @options)
     assert_success response

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -497,13 +497,6 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:zip => "1234567890"})
   end
 
-  def test_cardholder_name_passing_with_card
-    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
-      (params[:credit_card][:cardholder_name] == "Longbob Longsen")
-    end.returns(braintree_result)
-    @gateway.purchase(100, credit_card("41111111111111111111"), :customer => {:first_name => "Longbob", :last_name => "Longsen"})
-  end
-
   def test_three_d_secure_pass_thru_handling
     Braintree::TransactionGateway.
       any_instance.

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -497,6 +497,27 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"), :billing_address => {:zip => "1234567890"})
   end
 
+  def test_cardholder_name_passing_with_card
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:credit_card][:cardholder_name] == "Longbob Longsen")
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card("41111111111111111111"), :customer => {:first_name => "Longbob", :last_name => "Longsen"})
+  end
+
+  def test_three_d_secure_pass_thru_handling
+    Braintree::TransactionGateway.
+      any_instance.
+      expects(:sale).
+      with(has_entries(three_d_secure_pass_thru: {
+        cavv: "cavv",
+        eci_flag: "eci",
+        xid: "xid",
+    })).
+   returns(braintree_result)
+
+    @gateway.purchase(100, credit_card("41111111111111111111"), three_d_secure: {cavv: "cavv", eci: "eci", xid: "xid"})
+  end
+
   def test_passes_recurring_flag
     @gateway = BraintreeBlueGateway.new(
       :merchant_id => 'test',


### PR DESCRIPTION
This is simply adding support to :three_d_secure_pass_thru params for
Braintree, documented here: https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#three_d_secure_pass_thru