### PR TITLE
Quickpay: Always send currency and amount to Quickpay on store card

### DIFF
--- a/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
+++ b/lib/active_merchant/billing/gateways/quickpay/quickpay_v4to7.rb
@@ -83,7 +83,7 @@ module ActiveMerchant #:nodoc:
         post = {}
 
         add_creditcard(post, creditcard, options)
-        add_amount(post, 0, options) if @protocol >= 7
+        add_amount(post, 0, options)
         add_invoice(post, options)
         add_description(post, options)
         add_fraud_parameters(post, options)

--- a/test/unit/gateways/quickpay_v4to7_test.rb
+++ b/test/unit/gateways/quickpay_v4to7_test.rb
@@ -192,7 +192,9 @@ class QuickpayV4to7Test < Test::Unit::TestCase
 
   def expected_store_parameters_v6
     {
+      "amount"=>["0"],
       "cardnumber"=>["4242424242424242"],
+      "currency"=>["DKK"],
       "cvd"=>["123"],
       "expirationdate"=>[expected_expiration_date],
       "ordernumber"=>["fa73664073e23597bbdd"],


### PR DESCRIPTION
This removes the condition `if @protocol >= 7` so the amount and the currency will be sent to `:subscribe` requests made over the v3 protocol.

The reason for this is a change on the part of Quickpay now requiring this information to be present.

This change was implemented previously: https://github.com/chargify/active_merchant/pull/39 but was inadvertently reverted in https://github.com/chargify/active_merchant/pull/64 -- this PR is adding the change back in this time with test updates to ensure the change remains. 