### PR TITLE
Stripe payment intents API (3D Secure)

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -536,7 +536,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(success, url, method, response)
-        return response["error"]["payment_intent"] unless success
+        return response.dig("error", "payment_intent", "id") unless success
 
         if url == "customers"
           [response["id"], response["sources"]["data"].first["id"]].join("|")

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -531,7 +531,7 @@ module ActiveMerchant #:nodoc:
 
       def response_status_to_response_message_mapper(response)
         {
-          requires_source_action: "Your card was declined. This transaction requires authentication."
+          requires_source_action: "Your card was declined. This transaction requires 3D secure authentication."
         }.fetch(response["status"].to_sym, response["status"])
       end
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -72,7 +72,7 @@ module ActiveMerchant #:nodoc:
             else
               post[:capture] = "false"
             end
-            commit(:post, 'charges', post, options)
+            commit(:post, 'payment_intents', post, options)
           end
         end.responses.last
       end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -92,7 +92,6 @@ module ActiveMerchant #:nodoc:
 
         if options[:payment_to_confirm]
           r = commit(:post, "payment_intents/#{options[:payment_to_confirm]}/confirm", {}, options)
-          binding.pry
           return r
         end
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -130,6 +130,11 @@ module ActiveMerchant #:nodoc:
         post[:expand] = [:charge]
 
         MultiResponse.run(:first) do |r|
+          # If identification starts with pi_ then it is created with new payment intents API, so we need to fetch charge id from API
+          if identification =~ /\Api_/
+            r.process { commit(:get, "charges?payment_intent=#{CGI.escape(identification)}", nil, options) }
+            identification = r.responses.last.params["data"].first["id"]
+          end
           r.process { commit(:post, "charges/#{CGI.escape(identification)}/refunds", post, options) }
 
           return r unless options[:refund_fee_amount]

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -538,7 +538,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def authorization_from(success, url, method, response)
-        return response.dig("error", "payment_intent", "id") unless success
+        return response.dig("error", "payment_intent", "id") || response["id"] unless success
 
         if url == "customers"
           [response["id"], response["sources"]["data"].first["id"]].join("|")

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -518,10 +518,16 @@ module ActiveMerchant #:nodoc:
 
       def response_message(success, url, response)
         if url == "payment_intents"
-          success ? "Transaction approved" : response.dig("error", "message") || response["status"]
+          success ? "Transaction approved" : response.dig("error", "message") || response_status_to_response_message_mapper(response)
         else
           success ? "Transaction approved" : response["error"]["message"]
         end
+      end
+
+      def response_status_to_response_message_mapper(response)
+        {
+          requires_source_action: "Your card was declined. This transaction requires authentication."
+        }.fetch(response["status"].to_sym, response["status"])
       end
 
       def authorization_from(success, url, method, response)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -102,12 +102,7 @@ module ActiveMerchant #:nodoc:
           end
           r.process do
             post = create_post_for_auth_or_purchase(money, payment, options)
-
-            if options[:three_d_secure]
-              commit(:post, 'payment_intents', post, options)
-            else
-              commit(:post, 'charges', post, options)
-            end
+            commit(:post, options[:three_d_secure] ? 'payment_intents' : 'charges', post, options)
           end
         end.responses.last
       end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -90,6 +90,12 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, direct_bank_error)
         end
 
+        if options[:payment_to_confirm]
+          r = commit(:post, "payment_intents/#{options[:payment_to_confirm]}/confirm", {}, options)
+          binding.pry
+          return r
+        end
+
         MultiResponse.run do |r|
           if payment.is_a?(ApplePayPaymentToken)
             r.process { tokenize_apple_pay_token(payment) }

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -515,7 +515,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def success_response?(url, response)
-        if url == "payment_intents"
+        if url =~ /\Apayment_intents/
           !response.key?("error") && response["status"] == "succeeded"
         else
           !response.key?("error")
@@ -523,7 +523,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def response_message(success, url, response)
-        if url == "payment_intents"
+        if url =~ /\Apayment_intents/
           success ? "Transaction approved" : response.dig("error", "message") || response_status_to_response_message_mapper(response)
         else
           success ? "Transaction approved" : response["error"]["message"]

--- a/test/unit/gateways/stripe_test.rb
+++ b/test/unit/gateways/stripe_test.rb
@@ -394,6 +394,18 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_payment_intents
+    @gateway.expects(:add_creditcard)
+    @gateway.expects(:ssl_request).returns(successful_purchase_response_with_payment_intents)
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(three_d_secure: true))
+    assert_instance_of Response, response
+    assert_success response
+
+    assert_equal 'pi_test_payment_intents', response.authorization
+    assert response.test?
+  end
+
   def test_successful_purchase_with_token_string
     @gateway.expects(:add_creditcard)
     @gateway.expects(:ssl_request).returns(successful_purchase_response)
@@ -405,6 +417,17 @@ class StripeTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_purchase_with_token_string_and_with_payment_intents
+    @gateway.expects(:add_creditcard)
+    @gateway.expects(:ssl_request).returns(successful_purchase_response_with_payment_intents)
+
+    assert response = @gateway.purchase(@amount, @token_string, @options.merge(three_d_secure: true))
+    assert_success response
+
+    assert_equal 'pi_test_payment_intents', response.authorization
+    assert response.test?
+  end
+
   def test_successful_purchase_with_payment_token
     @gateway.expects(:add_payment_token)
     @gateway.expects(:ssl_request).returns(successful_purchase_response)
@@ -413,6 +436,17 @@ class StripeTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal 'ch_test_charge', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_payment_token_and_with_payment_intents
+    @gateway.expects(:add_payment_token)
+    @gateway.expects(:ssl_request).returns(successful_purchase_response_with_payment_intents)
+
+    assert response = @gateway.purchase(@amount, @payment_token, @options.merge(three_d_secure: true))
+    assert_success response
+
+    assert_equal 'pi_test_payment_intents', response.authorization
     assert response.test?
   end
 
@@ -1703,6 +1737,27 @@ class StripeTest < Test::Unit::TestCase
         "object": "card",
         "type": "Visa"
       }
+    }
+    RESPONSE
+  end
+
+  def successful_purchase_response_with_payment_intents
+    <<-RESPONSE
+    {
+      "id": "pi_test_payment_intents",
+      "description": "Test Purchase",
+      "object": "payment_intent",
+      "amount": 400,
+      "amount_capturable": 0,
+      "amount_received": 400,
+      "application_fee_amount": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "status": "succeeded",
+      "livemode": false,
+      "created": 1309131571,
+      "currency": "usd"
     }
     RESPONSE
   end


### PR DESCRIPTION
This add support for Stripe payment intents API that is required for 3D secure.

No changes in remote tests, because they are already failing for Stripe, also we have tests in Conduit and in Chargify.
  
Co-authored-by: Zbigniew Humeniuk <zbigniew@chargify.com>