### PR TITLE
[feature] Add 3D Secure 2.x support to CyberSource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -687,10 +687,14 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_threeds_services(xml, options)
-        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} if options[:payer_auth_enroll_service]
+        xml.tag! 'payerAuthEnrollService', {'run' => 'true'} do
+          xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id]
+        end if options[:payer_auth_enroll_service]
+
         if options[:payer_auth_validate_service]
           xml.tag! 'payerAuthValidateService', {'run' => 'true'} do
-            xml.tag! 'signedPARes', options[:pares]
+            xml.tag! 'signedPARes', options[:pares] if options[:pares]
+            xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
           end
         end
       end

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -84,7 +84,9 @@ module ActiveMerchant #:nodoc:
         :r247 => 'You requested a credit for a capture that was previously voided',
         :r250 => 'The request was received, but a time-out occurred with the payment processor',
         :r254 => 'Your CyberSource account is prohibited from processing stand-alone refunds',
-        :r255 => 'Your CyberSource account is not configured to process the service in the country you specified'
+        :r255 => 'Your CyberSource account is not configured to process the service in the country you specified',
+        :r475 => 'The customer is enrolled in payer authentication. Authenticate the cardholder before continuing with the transaction.',
+        :r476 => 'The customer cannot be authenticated'
       }
 
       # These are the options that can be used when creating a new CyberSource
@@ -688,7 +690,8 @@ module ActiveMerchant #:nodoc:
 
       def add_threeds_services(xml, options)
         xml.tag! 'payerAuthEnrollService', {'run' => 'true'} do
-          xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id]
+          xml.tag! 'authenticationTransactionID', options[:authentication_transaction_id] if options[:authentication_transaction_id]
+          xml.tag! 'referenceID', options[:reference_id] if options[:reference_id]
         end if options[:payer_auth_enroll_service]
 
         if options[:payer_auth_validate_service]

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -436,8 +436,8 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
   end
 
   # HYBRID 2.0
-  # WIP
-  def test_3ds_pa_auth
+  # `authentication_transaction_id` and `reference_id` are returned by MPI. Update those before run.
+  def test_3ds_payer_auth_request
     card = credit_card('4000000000001091',
                        verification_value: '111',
                        month: '01',
@@ -445,13 +445,12 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
                        brand: :visa
     )
 
-    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_enroll_service: false, payer_auth_validate_service: true, authentication_transaction_id: '1w0zWt0jSs36O3mU9ax0', pares: "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1ZDBiZTc3NGFmYTgwZDE0OGNmNTE3MTkiLCJpYXQiOjE1NjIxNTU2MjMsImV4cCI6MTU2MjE2MjgyMywianRpIjoiNWQ0YjQ1MjItNTNmNC00YzAzLWIzMzItNDc2MjRlOWEwOGI2IiwiQ29uc3VtZXJTZXNzaW9uSWQiOiIwXzg2OWVjMWUzLTM4M2QtNGFkZi05N2NlLTU3MjViMGRmZmFhMCIsImF1ZCI6IjE1NjIxNTU1NDMvOTU1MjY1Nnl3NnZsbWZldGx6ZXFteWxnMXRnOTZ2YjJod290a2ZtZjM2OXE3ZzRndThrbzh1d3ZzcWsxYWY3aCIsIlBheWxvYWQiOnsiUGF5bWVudCI6eyJUeXBlIjoiQ0NBIiwiUHJvY2Vzc29yVHJhbnNhY3Rpb25JZCI6IkZRWVpYZFFqekNLMm1YMnh3MXgwIn0sIkVycm9yTnVtYmVyIjowLCJFcnJvckRlc2NyaXB0aW9uIjoiU3VjY2VzcyJ9fQ.oPKaQT76CQ7PzMfAj9HYXSy2wAe2iTbzmxnEWS08cs8"))
-    pp response
+    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_validate_service: true, authentication_transaction_id: 'MLK3OjdxxoYDT6RWK5r0'))
     assert response.success?
     assert_equal '100', response.params['reasonCode']
   end
 
-  def test_3ds_enroll
+  def test_3ds_payer_auth_enroll
     card = credit_card('4000000000001091',
                        verification_value: '111',
                        month: '01',
@@ -459,10 +458,14 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
                        brand: :visa
     )
 
-    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_enroll_service: true))
-    pp response
+    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_enroll_service: true, reference_id: '0_097aff87-17fe-42e9-a3b4-0d1b9df6c49d'))
+    assert_equal '475', response.params['reasonCode']
+    assert !response.params['acsURL'].blank?
+    assert !response.params['paReq'].blank?
+    assert_equal 'Y', response.params['veresEnrolled']
+    assert !response.success?
   end
-  # /WIP
+  # / HYBRID
 
   def test_successful_first_unscheduled_cof_transaction
     @options[:stored_credential] = {

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -435,6 +435,35 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert !response.success?
   end
 
+  # HYBRID 2.0
+  # WIP
+  def test_3ds_pa_auth
+    card = credit_card('4000000000001091',
+                       verification_value: '111',
+                       month: '01',
+                       year: (Time.now.year + 3).to_s,
+                       brand: :visa
+    )
+
+    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_enroll_service: false, payer_auth_validate_service: true, authentication_transaction_id: '1w0zWt0jSs36O3mU9ax0', pares: "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1ZDBiZTc3NGFmYTgwZDE0OGNmNTE3MTkiLCJpYXQiOjE1NjIxNTU2MjMsImV4cCI6MTU2MjE2MjgyMywianRpIjoiNWQ0YjQ1MjItNTNmNC00YzAzLWIzMzItNDc2MjRlOWEwOGI2IiwiQ29uc3VtZXJTZXNzaW9uSWQiOiIwXzg2OWVjMWUzLTM4M2QtNGFkZi05N2NlLTU3MjViMGRmZmFhMCIsImF1ZCI6IjE1NjIxNTU1NDMvOTU1MjY1Nnl3NnZsbWZldGx6ZXFteWxnMXRnOTZ2YjJod290a2ZtZjM2OXE3ZzRndThrbzh1d3ZzcWsxYWY3aCIsIlBheWxvYWQiOnsiUGF5bWVudCI6eyJUeXBlIjoiQ0NBIiwiUHJvY2Vzc29yVHJhbnNhY3Rpb25JZCI6IkZRWVpYZFFqekNLMm1YMnh3MXgwIn0sIkVycm9yTnVtYmVyIjowLCJFcnJvckRlc2NyaXB0aW9uIjoiU3VjY2VzcyJ9fQ.oPKaQT76CQ7PzMfAj9HYXSy2wAe2iTbzmxnEWS08cs8"))
+    pp response
+    assert response.success?
+    assert_equal '100', response.params['reasonCode']
+  end
+
+  def test_3ds_enroll
+    card = credit_card('4000000000001091',
+                       verification_value: '111',
+                       month: '01',
+                       year: (Time.now.year + 3).to_s,
+                       brand: :visa
+    )
+
+    assert response = @gateway.purchase(1000, card, @options.merge(payer_auth_enroll_service: true))
+    pp response
+  end
+  # /WIP
+
   def test_successful_first_unscheduled_cof_transaction
     @options[:stored_credential] = {
       :initiator => 'cardholder',


### PR DESCRIPTION
This PR adds support for sending `authenticationTransactionID` and `referenceID` to the CyberSource which are used in 3DS 2.x flow.