### PR TITLE
Braintree: Adds support for transaction_source

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -617,7 +617,9 @@ module ActiveMerchant #:nodoc:
           parameters[:merchant_account_id] = merchant_account_id
         end
 
-        if options[:recurring]
+        if options[:transaction_source]
+          parameters[:transaction_source] = options[:transaction_source]
+        elsif options[:recurring]
           parameters[:recurring] = true
         end
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -273,6 +273,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal '510510', @braintree_backend.customer.find(response.params["customer_vault_id"]).credit_cards[0].bin
   end
 
+  def test_purchase_with_transaction_source
+    assert response = @gateway.store(@credit_card)
+    assert_success response
+    customer_vault_id = response.params['customer_vault_id']
+
+    assert response = @gateway.purchase(@amount, customer_vault_id, @options.merge(:transaction_source => 'unscheduled'))
+    assert_success response
+    assert_equal '1000 Approved', response.message
+  end
+
   def test_purchase_using_specified_payment_method_token
     assert response = @gateway.store(
       credit_card('4111111111111111',

--- a/test/unit/gateways/braintree_blue_test.rb
+++ b/test/unit/gateways/braintree_blue_test.rb
@@ -532,6 +532,14 @@ class BraintreeBlueTest < Test::Unit::TestCase
     @gateway.purchase(100, credit_card("41111111111111111111"))
   end
 
+  def test_passes_transaction_source
+    Braintree::TransactionGateway.any_instance.expects(:sale).with do |params|
+      (params[:transaction_source] == 'recurring')
+      (params[:recurring] == nil)
+    end.returns(braintree_result)
+    @gateway.purchase(100, credit_card('41111111111111111111'), :transaction_source => 'recurring', :recurring => true)
+  end
+
   def test_configured_logger_has_a_default
     # The default is actually provided by the Braintree gem, but we
     # assert its presence in order to show ActiveMerchant need not


### PR DESCRIPTION
Cherry Pick from the original Active Merchant.

This change adds ability to pass transaction_source parameter to BrainTree gateway.

Braintree is storing stored_credential on their side, but we need to pass transaction_source parameter with request.