### PR TITLE
Cybersource: Allow partial update of credit card

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -471,7 +471,7 @@ module ActiveMerchant #:nodoc:
 
       def add_creditcard(xml, creditcard)
         xml.tag! 'card' do
-          xml.tag! 'accountNumber', creditcard.number
+          xml.tag!('accountNumber', creditcard.number) unless creditcard.number.blank?
           xml.tag! 'expirationMonth', format(creditcard.month, :two_digits)
           xml.tag! 'expirationYear', format(creditcard.year, :four_digits)
           xml.tag!('cvNumber', creditcard.verification_value) unless @options[:ignore_cvv] || creditcard.verification_value.blank?


### PR DESCRIPTION
When sending partial card details to Cybersource, an account number is
not required. The presence of the `accountNumber` element in the request
forces validation, and so a "Invalid account number. (231)" response
will be given when the account number is not provided, even though it is
optional for update.

This change ensures that the `<accountNumber/>` element is only included
in the request if there is a card number provided.