### PR TITLE
Braintree 3ds ssp

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -169,6 +169,11 @@ module ActiveMerchant #:nodoc:
         true
       end
 
+      def three_d_secure_info(payment_method_nonce)
+        result = @braintree_gateway.payment_method_nonce.find(payment_method_nonce)
+        return result.payment_method_nonce.three_d_secure_info
+      end
+
       private
 
       def check_customer_exists(customer_vault_id)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -277,15 +277,20 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, 'Braintree::NotFoundError') if braintree_credit_card.nil?
 
           options.merge!(:update_existing_token => braintree_credit_card.token)
-          credit_card_params = merge_credit_card_options({
-            :credit_card => {
-              :cardholder_name => creditcard.name,
-              :number => creditcard.number,
-              :cvv => creditcard.verification_value,
-              :expiration_month => creditcard.month.to_s.rjust(2, "0"),
-              :expiration_year => creditcard.year.to_s
-            }
-          }, options)[:credit_card]
+
+          if options[:payment_method_nonce]
+            credit_card_params = { payment_method_nonce: options[:payment_method_nonce] }
+          else
+            credit_card_params = merge_credit_card_options({
+               :credit_card => {
+                 :cardholder_name => creditcard.name,
+                 :number => creditcard.number,
+                 :cvv => creditcard.verification_value,
+                 :expiration_month => creditcard.month.to_s.rjust(2, "0"),
+                 :expiration_year => creditcard.year.to_s
+               }
+             }, options)[:credit_card]
+          end
 
           parameters = {
             :first_name => creditcard.first_name,

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -172,6 +172,8 @@ module ActiveMerchant #:nodoc:
       def three_d_secure_info(payment_method_nonce)
         result = @braintree_gateway.payment_method_nonce.find(payment_method_nonce)
         return result.payment_method_nonce.three_d_secure_info
+      rescue Braintree::NotFoundError => e
+        e
       end
 
       private

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -277,20 +277,15 @@ module ActiveMerchant #:nodoc:
           return Response.new(false, 'Braintree::NotFoundError') if braintree_credit_card.nil?
 
           options.merge!(:update_existing_token => braintree_credit_card.token)
-
-          if options[:payment_method_nonce]
-            credit_card_params = { payment_method_nonce: options[:payment_method_nonce] }
-          else
-            credit_card_params = merge_credit_card_options({
-               :credit_card => {
-                 :cardholder_name => creditcard.name,
-                 :number => creditcard.number,
-                 :cvv => creditcard.verification_value,
-                 :expiration_month => creditcard.month.to_s.rjust(2, "0"),
-                 :expiration_year => creditcard.year.to_s
-               }
-             }, options)[:credit_card]
-          end
+          credit_card_params = merge_credit_card_options({
+            :credit_card => {
+              :cardholder_name => creditcard.name,
+              :number => creditcard.number,
+              :cvv => creditcard.verification_value,
+              :expiration_month => creditcard.month.to_s.rjust(2, "0"),
+              :expiration_year => creditcard.year.to_s
+            }
+          }, options)[:credit_card]
 
           parameters = {
             :first_name => creditcard.first_name,

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -638,6 +638,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
+  def test_three_d_secure_info_with_valid_nonce
+    assert response = @gateway.three_d_secure_info("fake-three-d-secure-visa-full-authentication-nonce")
+    assert_equal Braintree::ThreeDSecureInfo, response.class
+  end
+
+  def test_three_d_secure_info_with_invalid_nonce
+    assert response = @gateway.three_d_secure_info("invalid-nonce")
+    assert_equal Braintree::NotFoundError, response.class
+  end
+
   private
   def assert_avs(address1, zip, expected_avs_code)
     response = @gateway.purchase(@amount, @credit_card, billing_address: {address1: address1, zip: zip})


### PR DESCRIPTION
This change is needed for Braintree 3DS auth on SSP to work.

Related task: https://trello.com/c/52kfMc6T/553-braintree-ssp-3ds-store-authorizations