### PR TITLE
[change] Change three_d_secure_info to check_payment_method_nonce

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -169,11 +169,11 @@ module ActiveMerchant #:nodoc:
         true
       end
 
-      def three_d_secure_info(payment_method_nonce)
+      def check_payment_method_nonce(payment_method_nonce)
         result = @braintree_gateway.payment_method_nonce.find(payment_method_nonce)
-        return result.payment_method_nonce.three_d_secure_info
-      rescue Braintree::NotFoundError => e
-        e
+        Response.new(true, 'OK', { payment_method_nonce: result.payment_method_nonce })
+      rescue Braintree::NotFoundError
+        return Response.new(false, 'Braintree::NotFoundError')
       end
 
       private

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -638,14 +638,16 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert !gateway.verify_credentials
   end
 
-  def test_three_d_secure_info_with_valid_nonce
-    assert response = @gateway.three_d_secure_info("fake-three-d-secure-visa-full-authentication-nonce")
-    assert_equal Braintree::ThreeDSecureInfo, response.class
+  def test_check_payment_method_nonce_with_valid_nonce
+    assert response = @gateway.check_payment_method_nonce("fake-three-d-secure-visa-full-authentication-nonce")
+    assert_success response
+    assert_equal 'OK', response.message
   end
 
-  def test_three_d_secure_info_with_invalid_nonce
-    assert response = @gateway.three_d_secure_info("invalid-nonce")
-    assert_equal Braintree::NotFoundError, response.class
+  def test_check_payment_method_nonce_with_invalid_nonce
+    assert response = @gateway.check_payment_method_nonce("invalid-nonce")
+    assert_failure response
+    assert_equal 'Braintree::NotFoundError', response.message
   end
 
   private


### PR DESCRIPTION
This PR changes `three_d_secure_info` name to `check_payment_method_nonce` and uses `Response`s as results.