### PR TITLE
Braintree: Pass payment_method_nonce if present during purchase

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -635,7 +635,7 @@ module ActiveMerchant #:nodoc:
             parameters[:payment_method_token] = credit_card_or_vault_id
             options.delete(:billing_address)
           elsif options[:payment_method_nonce]
-            parameters[:payment_method_nonce] = credit_card_or_vault_id
+            parameters[:payment_method_nonce] = options[:payment_method_nonce]
           else
             parameters[:customer_id] = credit_card_or_vault_id
           end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -635,7 +635,7 @@ module ActiveMerchant #:nodoc:
             parameters[:payment_method_token] = credit_card_or_vault_id
             options.delete(:billing_address)
           elsif options[:payment_method_nonce]
-            parameters[:payment_method_nonce] = options[:payment_method_nonce]
+            parameters[:payment_method_nonce] = credit_card_or_vault_id
           else
             parameters[:customer_id] = credit_card_or_vault_id
           end
@@ -685,6 +685,7 @@ module ActiveMerchant #:nodoc:
           }
         end
 
+        parameters[:payment_method_nonce] = options[:three_ds_token] if options[:three_ds]
         parameters
       end
     end


### PR DESCRIPTION
#### Description
During `purchase` action `payment_method_nonce` was overwritten by `credit_card_or_vault_id `. I don't have history knowledge of that decision but in order to validate SCA, I need to pass original`payment_method_nonce` to Braintree.

### Orginal commit with overwrite
https://github.com/activemerchant/active_merchant/commit/c15a58a9bc866f9442b4b5d797d1f2aafc01dd0b

### `Transaction.sale()` docs:
https://developers.braintreepayments.com/reference/request/transaction/sale/ruby