### PR TITLE
PaymentExpress: update scrubbing

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -123,13 +123,14 @@ module ActiveMerchant #:nodoc:
         commit(:validate, request)
       end
 
-      def supports_scrubbing
+      def supports_scrubbing?
         true
       end
 
       def scrub(transcript)
         transcript.
-          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+          gsub(%r((<PostPassword>).+(</PostPassword>)), '\1[FILTERED]\2').
+          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]\2').
           gsub(%r((<CardNumber>)\d+(</CardNumber>)), '\1[FILTERED]\2').
           gsub(%r((<Cvc2>)\d+(</Cvc2>)), '\1[FILTERED]\2')
       end

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -433,6 +433,6 @@ class PaymentExpressTest < Test::Unit::TestCase
   end
 
   def scrubbed_transcript
-    %(<Txn><CardHolderName>Longbob Longsen</CardHolderName><CardNumber>[FILTERED]</CardNumber><DateExpiry>0916</DateExpiry><Cvc2>[FILTERED]</Cvc2><Cvc2Presence>1</Cvc2Presence><Amount>1.00</Amount><InputCurrency>NZD</InputCurrency><TxnId>59956b468905bde7</TxnId><MerchantReference>Store purchase</MerchantReference><EnableAvsData>1</EnableAvsData><AvsAction>1</AvsAction><AvsStreetAddress>456 My Street</AvsStreetAddress><AvsPostCode>K1C2N6</AvsPostCode><PostUsername>WaysactDev</PostUsername><PostPassword>kvr52dw9</PostPassword><TxnType>Purchase</TxnType></Txn>)
+    %(<Txn><CardHolderName>Longbob Longsen</CardHolderName><CardNumber>[FILTERED]</CardNumber><DateExpiry>0916</DateExpiry><Cvc2>[FILTERED]</Cvc2><Cvc2Presence>1</Cvc2Presence><Amount>1.00</Amount><InputCurrency>NZD</InputCurrency><TxnId>59956b468905bde7</TxnId><MerchantReference>Store purchase</MerchantReference><EnableAvsData>1</EnableAvsData><AvsAction>1</AvsAction><AvsStreetAddress>456 My Street</AvsStreetAddress><AvsPostCode>K1C2N6</AvsPostCode><PostUsername>WaysactDev</PostUsername><PostPassword>[FILTERED]</PostPassword><TxnType>Purchase</TxnType></Txn>)
   end
 end


### PR DESCRIPTION
This change updates PaymentExpress scrub method to filter `PostPassword` and changes `supports_scrubbing` method to `supports_scrubbing?` like it is in most of other gateways.