### PR TITLE
Stripe: throws an exception when payment methods for customer returns error

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -333,6 +333,8 @@ module ActiveMerchant #:nodoc:
       def card_payment_method_for_customer(customer)
         # if customer has only one payment method we choose that one
         r = commit(:get, "payment_methods?customer=#{customer}&type=card", nil, options)
+        raise r.message unless r.success?
+
         payment_methods = r.params["data"]
         return payment_methods[0]["id"] if payment_methods&.count == 1
 


### PR DESCRIPTION
This will throws an exception in case when payment methods api for customer returns an error.

### Why?
It occurred on production that client can remove customer from Stripe, and when that happens payment methods API for customer will returns error instead of proper response.