### PR TITLE
Stripe: add support for customer default source sets as source

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -347,6 +347,11 @@ module ActiveMerchant #:nodoc:
         default_source = r.params["default_source"]
         return default_source if default_source&.start_with?("card_")
 
+        if default_source&.start_with?("src_")
+          r = commit(:get, "sources/#{default_source}", nil, options)
+          return r.params["id"] if r.params["type"] == "card"
+        end
+
         if payment_methods&.count > 1 && !default_payment_method
           raise "Customer has more than one payment method but doesn't have default one."
         end


### PR DESCRIPTION
This adds suport for Stripe's scenario when customer has default_source sets as source (src_)