### PR TITLE
Support MOTO transactions for CyberSource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -532,10 +532,13 @@ module ActiveMerchant #:nodoc:
       end
 
       def commerce_indicator(options)
-        return if options[:stored_credential][:initial_transaction]
+        return if options[:stored_credential][:initial_transaction] &&
+          options[:stored_credential][:reason_type] != 'internet'
+
         case options[:stored_credential][:reason_type]
         when 'installment' then 'install'
         when 'recurring' then 'recurring'
+        when 'internet' then 'internet'
         end
       end
 


### PR DESCRIPTION
## Why?
We need to be able to send the value `internet` to cybersource for the `commerceIndicator` to indicate that the transaction was merchant initiated.

## What?
We can now return `internet` out of the `commerce_indicator` method if the reason is not already to set to internet and its the initial transaction.