### PR TITLE
Increase ActiveSupport dependency version up to 5.2

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 5.1')
+  s.add_dependency('activesupport', '>= 3.2.14', '<= 5.2')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
Necessary for Rails 5.2 compatibility. There were no braking changes since 5.0.0. 