### PR TITLE
[internal] Revert Paymill-specific changes

### DIFF
--- a/test/remote/gateways/remote_paymill_test.rb
+++ b/test/remote/gateways/remote_paymill_test.rb
@@ -137,24 +137,6 @@ class RemotePaymillTest < Test::Unit::TestCase
     assert_success purchase
   end
 
-  def test_successful_store_with_multiple_purchases
-    store = @gateway.store(@credit_card)
-    assert_success store
-    assert_not_nil store.authorization
-
-    # Do first purchase with the token (i.e. tok_abc123)
-    purchase_1 = @gateway.purchase(@amount, store.authorization)
-    payment_id = purchase_1.params['data']['payment']['id']
-
-    # Do next payment with the payment id (i.e. pay_abc123)
-    purchase_2 = @gateway.purchase(@amount, payment_id, { description: 'something' })
-    assert_success purchase_2
-
-    # Do subsequent payments with the same payment id (i.e. pay_abc123)
-    purchase_3 = @gateway.purchase(@amount, payment_id, { description: 'something else' })
-    assert_success purchase_3
-  end
-
   def test_failed_store_with_invalid_card
     @credit_card.number = ''
     assert response = @gateway.store(@credit_card)


### PR DESCRIPTION
[JIRA - PGT-65](https://chargify.atlassian.net/jira/software/projects/PGT/boards/32?selectedIssue=PGT-65)
Dependency of https://github.com/chargify/conduit/pull/252
Dependency of https://github.com/chargify/chargify/pull/15282

## Why

We should remove all traces of the Paymill gateway from our codebase since it's not being used or offered anymore 🔥🔥🔥

## How

I did some git sleuthing[1] to try to determine what changes we had made to our ActiveMerchant fork related to Paymill and I found [this commit](https://github.com/chargify/active_merchant/commit/bbeee0b0a06ad91c39bf7595264d6af1c0d82974). This PR reverts it since Paymill has been deleted from Chargify and Conduit and there's no reason to deviate from the main ActiveMerchant branch.

[1]:
```
pedrocoronel:~/code/active_merchant [master|⚑ 1] $ git remote add original https://github.com/activemerchant/active_merchant
pedrocoronel:~/code/active_merchant [master|⚑ 1] $ git fetch original
pedrocoronel:~/code/active_merchant [master|⚑ 1] $ git log original/master.. | grep -i -B 4 paymill
commit bbeee0b0a06ad91c39bf7595264d6af1c0d82974
Author: Nathan Verni <npverni@gmail.com>
Date:   Fri Jul 4 13:47:07 2014 -0400
    PayMill Updates:```