### PR TITLE
[feature] enable updates for apple pay cards

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -315,7 +315,6 @@ module ActiveMerchant #:nodoc:
 
           # Delete the customers existing payment methods
           customer.paypal_accounts.each { |pp| @braintree_gateway.paypal_account.delete(pp.token) }
-          # Updating apple pay accounts is tested in Chargify
           customer.apple_pay_cards.each { |pp| @braintree_gateway.payment_method.delete(pp.token) }
 
           # Update it with the new nonce

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -315,6 +315,7 @@ module ActiveMerchant #:nodoc:
 
           # Delete the customers existing payment methods
           customer.paypal_accounts.each { |pp| @braintree_gateway.paypal_account.delete(pp.token) }
+          customer.apple_pay_cards.each { |pp| @braintree_gateway.payment_method.delete(pp.token) }
 
           # Update it with the new nonce
           parameters = {

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -315,6 +315,7 @@ module ActiveMerchant #:nodoc:
 
           # Delete the customers existing payment methods
           customer.paypal_accounts.each { |pp| @braintree_gateway.paypal_account.delete(pp.token) }
+          # Updating apple pay accounts is tested in Chargify
           customer.apple_pay_cards.each { |pp| @braintree_gateway.payment_method.delete(pp.token) }
 
           # Update it with the new nonce


### PR DESCRIPTION
Enables updating apple pay card on Braintree customer to a new one.
The `customer.paypal_accounts.each { |pp| @braintree_gateway.paypal_account.delete(pp.token) }` method has not been tested in neither this fork nor master. The method added in this PR is tested via Chargify tests. 