### PR TITLE
Adyen Checkout

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -1,0 +1,444 @@
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class AdyenCheckoutGateway < Gateway
+      self.test_url = 'https://checkout-test.adyen.com/'
+      self.live_url = 'https://checkout-live.adyen.com/'
+
+      self.supported_countries = %w(AT AU BE BG BR CH CY CZ DE DK EE ES FI FR GB GI GR HK HU IE IS IT LI LT LU LV MC MT MX NL NO PL PT RO SE SG SK SI US)
+      self.default_currency = 'USD'
+      self.currencies_without_fractions = %w(CVE DJF GNF IDR JPY KMF KRW PYG RWF UGX VND VUV XAF XOF XPF)
+      self.supported_cardtypes = [:visa, :master, :american_express, :diners_club, :jcb, :dankort, :maestro, :discover, :elo, :naranja, :cabal, :unionpay]
+
+      self.money_format = :cents
+
+      self.homepage_url = 'https://www.adyen.com/'
+      self.display_name = 'Adyen'
+
+      PAYMENTS_API_VERSION = 'v51'
+
+      STANDARD_ERROR_CODE_MAPPING = {
+          '101' => STANDARD_ERROR_CODE[:incorrect_number],
+          '103' => STANDARD_ERROR_CODE[:invalid_cvc],
+          '131' => STANDARD_ERROR_CODE[:incorrect_address],
+          '132' => STANDARD_ERROR_CODE[:incorrect_address],
+          '133' => STANDARD_ERROR_CODE[:incorrect_address],
+          '134' => STANDARD_ERROR_CODE[:incorrect_address],
+          '135' => STANDARD_ERROR_CODE[:incorrect_address],
+      }
+
+      def initialize(options={})
+        requires!(options, :username, :password, :merchant_account)
+        @username, @password, @merchant_account = options.values_at(:username, :password, :merchant_account)
+        super
+      end
+
+      def purchase(money, payment, options={})
+        post = init_post(options)
+        add_invoice(post, money, options)
+        add_token(post, payment)
+        add_stored_credentials(post, payment, options)
+        add_shopper_reference(post, options)
+        commit('payments', post, options)
+      end
+
+      # Not implemented yet
+      def refund(money, authorization, options={})
+        post = init_post(options)
+        add_invoice_for_modification(post, money, options)
+        add_original_reference(post, authorization, options)
+        commit('refund', post, options)
+      end
+
+      def store(credit_card, options={})
+        requires!(options, :order_id)
+        post = init_post(options)
+        add_invoice(post, 0, options)
+        add_payment(post, credit_card, options)
+        add_extra_data(post, credit_card, options)
+        add_stored_credentials(post, credit_card, options)
+        add_address(post, options)
+
+        initial_response = commit('payments', post, options)
+
+        if initial_response.success? && card_not_stored?(initial_response)
+          unsupported_failure_response(initial_response)
+        else
+          initial_response
+        end
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+            gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
+            gsub(%r(("number\\?":\\?")[^"]*)i, '\1[FILTERED]').
+            gsub(%r(("cvc\\?":\\?")[^"]*)i, '\1[FILTERED]').
+            gsub(%r(("cavv\\?":\\?")[^"]*)i, '\1[FILTERED]')
+      end
+
+      private
+
+      AVS_MAPPING = {
+          '0'  => 'R',  # Unknown
+          '1'  => 'A',  # Address matches, postal code doesn't
+          '2'  => 'N',  # Neither postal code nor address match
+          '3'  => 'R',  # AVS unavailable
+          '4'  => 'E',  # AVS not supported for this card type
+          '5'  => 'U',  # No AVS data provided
+          '6'  => 'Z',  # Postal code matches, address doesn't match
+          '7'  => 'D',  # Both postal code and address match
+          '8'  => 'U',  # Address not checked, postal code unknown
+          '9'  => 'B',  # Address matches, postal code unknown
+          '10' => 'N',  # Address doesn't match, postal code unknown
+          '11' => 'U',  # Postal code not checked, address unknown
+          '12' => 'B',  # Address matches, postal code not checked
+          '13' => 'U',  # Address doesn't match, postal code not checked
+          '14' => 'P',  # Postal code matches, address unknown
+          '15' => 'P',  # Postal code matches, address not checked
+          '16' => 'N',  # Postal code doesn't match, address unknown
+          '17' => 'U',  # Postal code doesn't match, address not checked
+          '18' => 'I',  # Neither postal code nor address were checked
+          '19' => 'L',  # Name and postal code matches.
+          '20' => 'V',  # Name, address and postal code matches.
+          '21' => 'O',  # Name and address matches.
+          '22' => 'K',  # Name matches.
+          '23' => 'F',  # Postal code matches, name doesn't match.
+          '24' => 'H',  # Both postal code and address matches, name doesn't match.
+          '25' => 'T',  # Address matches, name doesn't match.
+          '26' => 'N'   # Neither postal code, address nor name matches.
+      }
+
+      CVC_MAPPING = {
+          '0' => 'P', # Unknown
+          '1' => 'M', # Matches
+          '2' => 'N', # Does not match
+          '3' => 'P', # Not checked
+          '4' => 'S', # No CVC/CVV provided, but was required
+          '5' => 'U', # Issuer not certifed by CVC/CVV
+          '6' => 'P'  # No CVC/CVV provided
+      }
+
+      NETWORK_TOKENIZATION_CARD_SOURCE = {
+          'apple_pay' => 'applepay',
+          'android_pay' => 'androidpay',
+          'google_pay' => 'paywithgoogle'
+      }
+
+      def add_extra_data(post, payment, options)
+        post[:telephoneNumber] = options[:billing_address][:phone] if options.dig(:billing_address, :phone)
+        post[:shopperEmail] = options[:shopper_email] if options[:shopper_email]
+        post[:shopperIP] = options[:shopper_ip] if options[:shopper_ip]
+        post[:shopperStatement] = options[:shopper_statement] if options[:shopper_statement]
+        post[:fraudOffset] = options[:fraud_offset] if options[:fraud_offset]
+        post[:selectedBrand] = options[:selected_brand] if options[:selected_brand]
+        post[:selectedBrand] ||= NETWORK_TOKENIZATION_CARD_SOURCE[payment.source.to_s] if payment.is_a?(NetworkTokenizationCreditCard)
+        post[:deliveryDate] = options[:delivery_date] if options[:delivery_date]
+        post[:merchantOrderReference] = options[:merchant_order_reference] if options[:merchant_order_reference]
+        post[:captureDelayHours] = options[:capture_delay_hours] if options[:capture_delay_hours]
+        post[:additionalData] ||= {}
+        post[:additionalData][:overwriteBrand] = normalize(options[:overwrite_brand]) if options[:overwrite_brand]
+        post[:additionalData][:customRoutingFlag] = options[:custom_routing_flag] if options[:custom_routing_flag]
+        post[:additionalData]['paymentdatasource.type'] = NETWORK_TOKENIZATION_CARD_SOURCE[payment.source.to_s] if payment.is_a?(NetworkTokenizationCreditCard)
+        post[:additionalData][:authorisationType] = options[:authorisation_type] if options[:authorisation_type]
+        post[:additionalData][:adjustAuthorisationData] = options[:adjust_authorisation_data] if options[:adjust_authorisation_data]
+        post[:additionalData][:industryUsage] = options[:industry_usage] if options[:industry_usage]
+        post[:additionalData][:updateShopperStatement] = options[:update_shopper_statement] if options[:update_shopper_statement]
+        post[:additionalData][:RequestedTestAcquirerResponseCode] = options[:requested_test_acquirer_response_code] if options[:requested_test_acquirer_response_code] && test?
+        post[:deviceFingerprint] = options[:device_fingerprint] if options[:device_fingerprint]
+        add_risk_data(post, options)
+        add_shopper_reference(post, options)
+      end
+
+      def add_risk_data(post, options)
+        if (risk_data = options[:risk_data])
+          risk_data = Hash[risk_data.map { |k, v| ["riskdata.#{k}", v] }]
+          post[:additionalData].merge!(risk_data)
+        end
+      end
+
+      def add_splits(post, options)
+        return unless split_data = options[:splits]
+
+        splits = []
+        split_data.each do |split|
+          amount = {
+              value: split['amount']['value'],
+          }
+          amount[:currency] = split['amount']['currency'] if split['amount']['currency']
+
+          split_hash = {
+              amount: amount,
+              type: split['type'],
+              reference: split['reference']
+          }
+          split_hash['account'] = split['account'] if split['account']
+          splits.push(split_hash)
+        end
+        post[:splits] = splits
+      end
+
+      def add_stored_credentials(post, payment, options)
+        add_shopper_interaction(post, payment, options)
+        add_recurring_processing_model(post, options)
+      end
+
+      def add_merchant_account(post, options)
+        post[:merchantAccount] = options[:merchant_account] || @merchant_account
+      end
+
+      def add_shopper_reference(post, options)
+        post[:shopperReference] = options[:shopper_reference] if options[:shopper_reference]
+      end
+
+      def add_shopper_interaction(post, payment, options={})
+        if options.dig(:stored_credential, :initial_transaction) || (payment.respond_to?(:verification_value) && payment.verification_value) || payment.is_a?(NetworkTokenizationCreditCard)
+          shopper_interaction = 'Ecommerce'
+        else
+          shopper_interaction = 'ContAuth'
+        end
+
+        post[:shopperInteraction] = options[:shopper_interaction] || shopper_interaction
+      end
+
+      def add_recurring_processing_model(post, options)
+        return unless options.dig(:stored_credential, :reason_type) || options[:recurring_processing_model]
+
+        if options.dig(:stored_credential, :reason_type) && options[:stored_credential][:reason_type] == 'unscheduled'
+          recurring_processing_model = 'CardOnFile'
+        else
+          recurring_processing_model = 'Subscription'
+        end
+
+        post[:recurringProcessingModel] = options[:recurring_processing_model] || recurring_processing_model
+      end
+
+      def add_address(post, options)
+        if address = options[:shipping_address]
+          post[:deliveryAddress] = {}
+          post[:deliveryAddress][:street] = address[:address1] || 'NA'
+          post[:deliveryAddress][:houseNumberOrName] = address[:address2] || 'NA'
+          post[:deliveryAddress][:postalCode] = address[:zip] if address[:zip]
+          post[:deliveryAddress][:city] = address[:city] || 'NA'
+          post[:deliveryAddress][:stateOrProvince] = get_state(address)
+          post[:deliveryAddress][:country] = address[:country] if address[:country]
+        end
+        return unless post[:card]&.kind_of?(Hash)
+
+        if (address = options[:billing_address] || options[:address]) && address[:country]
+          post[:billingAddress] = {}
+          post[:billingAddress][:street] = address[:address1] || 'NA'
+          post[:billingAddress][:houseNumberOrName] = address[:address2] || 'NA'
+          post[:billingAddress][:postalCode] = address[:zip] if address[:zip]
+          post[:billingAddress][:city] = address[:city] || 'NA'
+          post[:billingAddress][:stateOrProvince] = get_state(address)
+          post[:billingAddress][:country] = address[:country] if address[:country]
+        end
+      end
+
+      def get_state(address)
+        address[:state] && !address[:state].blank? ? address[:state] : 'NA'
+      end
+
+      def add_invoice(post, money, options)
+        currency = options[:currency] || currency(money)
+        amount = {
+            value: localized_amount(money, currency),
+            currency: currency
+        }
+        post[:amount] = amount
+      end
+
+      def add_invoice_for_modification(post, money, options)
+        currency = options[:currency] || currency(money)
+        amount = {
+            value: localized_amount(money, currency),
+            currency: currency
+        }
+        post[:modificationAmount] = amount
+      end
+
+      def add_payment(post, payment, options)
+        if payment.is_a?(String)
+          _, _, recurring_detail_reference = payment.split('#')
+          post[:selectedRecurringDetailReference] = recurring_detail_reference
+          options[:recurring_contract_type] ||= 'RECURRING'
+        else
+          add_mpi_data_for_network_tokenization_card(post, payment) if payment.is_a?(NetworkTokenizationCreditCard)
+          add_card(post, payment)
+        end
+      end
+
+      def add_card(post, credit_card)
+        card = {
+            expiryMonth: credit_card.month,
+            expiryYear: credit_card.year,
+            holderName: credit_card.name,
+            number: credit_card.number,
+            cvc: credit_card.verification_value,
+            type: "scheme"
+        }
+
+        card.delete_if { |k, v| v.blank? }
+        card[:holderName] ||= 'Not Provided' if credit_card.is_a?(NetworkTokenizationCreditCard)
+        requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
+        post[:paymentMethod] = card
+      end
+
+      def add_token(post, payment)
+        payment_method = {
+            type: "scheme",
+            storedPaymentMethodId: payment
+        }
+        post[:paymentMethod] = payment_method
+      end
+
+      def add_original_reference(post, authorization, options = {})
+        original_psp_reference, _, _ = authorization.split('#')
+        post[:originalReference] = single_reference(authorization) || original_psp_reference
+      end
+
+      def add_mpi_data_for_network_tokenization_card(post, payment)
+        post[:mpiData] = {}
+        post[:mpiData][:authenticationResponse] = 'Y'
+        post[:mpiData][:cavv] = payment.payment_cryptogram
+        post[:mpiData][:directoryResponse] = 'Y'
+        post[:mpiData][:eci] = payment.eci || '07'
+      end
+
+      def single_reference(authorization)
+        authorization if !authorization.include?('#')
+      end
+
+      def parse(body)
+        return {} if body.blank?
+
+        JSON.parse(body)
+      end
+
+      def commit(action, parameters, options)
+        begin
+          raw_response = ssl_post(url(action), post_data(action, parameters), request_headers(options))
+          response = parse(raw_response)
+        rescue ResponseError => e
+          raw_response = e.response.body
+          response = parse(raw_response)
+        end
+        success = success_from(action, response)
+        Response.new(
+            success,
+            message_from(action, response),
+            response,
+            authorization: authorization_from(action, parameters, response),
+            test: test?,
+            error_code: success ? nil : error_code_from(response),
+            avs_result: AVSResult.new(:code => avs_code_from(response)),
+            cvv_result: CVVResult.new(cvv_result_from(response))
+        )
+      end
+
+      def avs_code_from(response)
+        AVS_MAPPING[response['additionalData']['avsResult'][0..1].strip] if response.dig('additionalData', 'avsResult')
+      end
+
+      def cvv_result_from(response)
+        CVC_MAPPING[response['additionalData']['cvcResult'][0]] if response.dig('additionalData', 'cvcResult')
+      end
+
+      def endpoint(action)
+        "#{PAYMENTS_API_VERSION}/#{action}"
+      end
+
+      def url(action)
+        if test?
+          "#{test_url}#{endpoint(action)}"
+        elsif @options[:subdomain]
+          "https://#{@options[:subdomain]}-pal-live.adyenpayments.com/pal/servlet/#{endpoint(action)}"
+        else
+          "#{live_url}#{endpoint(action)}"
+        end
+      end
+
+      def basic_auth
+        Base64.strict_encode64("#{@username}:#{@password}")
+      end
+
+      def request_headers(options)
+        headers = {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Basic #{basic_auth}"
+        }
+        headers['Idempotency-Key'] = options[:idempotency_key] if options[:idempotency_key]
+        headers
+      end
+
+      def success_from(action, response)
+        case action.to_s
+        when 'payments'
+          ['Authorised', 'Received', 'RedirectShopper'].include?(response['resultCode'])
+        when 'refund'
+          response['response'] == "[#{action}-received]"
+        else
+          false
+        end
+      end
+
+      def message_from(action, response)
+        return authorize_message_from(response) if action.to_s == 'authorise' || action.to_s == 'authorise3d'
+
+        response['response'] || response['message'] || response['result']
+      end
+
+      def authorize_message_from(response)
+        if response['refusalReason'] && response['additionalData'] && response['additionalData']['refusalReasonRaw']
+          "#{response['refusalReason']} | #{response['additionalData']['refusalReasonRaw']}"
+        else
+          response['refusalReason'] || response['resultCode'] || response['message'] || response['result']
+        end
+      end
+
+      def authorization_from(action, parameters, response)
+        return nil if response['pspReference'].nil?
+
+        recurring = response['additionalData']['recurring.recurringDetailReference'] if response['additionalData']
+        recurring = response['recurringDetailReference'] if action == 'storeToken'
+
+        "#{parameters[:originalReference]}##{response['pspReference']}##{recurring}"
+      end
+
+      def init_post(options = {})
+        post = {}
+        add_merchant_account(post, options)
+        post[:reference] = options[:order_id] if options[:order_id]
+        post
+      end
+
+      def post_data(action, parameters = {})
+        JSON.generate(parameters)
+      end
+
+      def error_code_from(response)
+        STANDARD_ERROR_CODE_MAPPING[response['errorCode']]
+      end
+
+      def unsupported_failure_response(initial_response)
+        Response.new(
+            false,
+            'Recurring transactions are not supported for this card type.',
+            initial_response.params,
+            authorization: initial_response.authorization,
+            test: initial_response.test,
+            error_code: initial_response.error_code,
+            avs_result: initial_response.avs_result,
+            cvv_result: initial_response.cvv_result[:code]
+        )
+      end
+
+      def card_not_stored?(response)
+        response.authorization ? response.authorization.split('#')[2].nil? : true
+      end
+    end
+  end
+end

--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -47,7 +47,7 @@ module ActiveMerchant #:nodoc:
       def refund(money, authorization, options={})
         post = init_post(options)
         add_invoice_for_modification(post, money, options)
-        add_original_reference(post, authorization, options)
+        add_original_reference(post, authorization)
         commit('refund', post, options)
       end
 
@@ -56,7 +56,7 @@ module ActiveMerchant #:nodoc:
         post = init_post(options)
         add_invoice(post, 0, options)
         add_payment(post, credit_card)
-        add_extra_data(post, credit_card, options)
+        add_extra_data(post, options)
         add_stored_credentials(post, credit_card, options)
         add_address(post, options)
 
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
           '6' => 'P'  # No CVC/CVV provided
       }
 
-      def add_extra_data(post, payment, options)
+      def add_extra_data(post, options)
         post[:telephoneNumber] = options[:billing_address][:phone] if options.dig(:billing_address, :phone)
         post[:shopperEmail] = options[:shopper_email] if options[:shopper_email]
         post[:shopperIP] = options[:shopper_ip] if options[:shopper_ip]
@@ -276,18 +276,18 @@ module ActiveMerchant #:nodoc:
             type: "scheme"
         }
 
-        card.delete_if { |k, v| v.blank? }
+        card.delete_if { |_k, v| v.blank? }
         requires!(card, :expiryMonth, :expiryYear, :holderName, :number)
         post[:paymentMethod] = card
       end
 
-      def add_original_reference(post, authorization, options = {})
+      def add_original_reference(post, authorization)
         _, original_psp_reference, _ = authorization.split('#')
         post[:originalReference] = single_reference(authorization) || original_psp_reference
       end
 
       def single_reference(authorization)
-        authorization if !authorization.include?('#')
+        authorization unless authorization.include?('#')
       end
 
       def parse(body)
@@ -404,7 +404,7 @@ module ActiveMerchant #:nodoc:
         post
       end
 
-      def post_data(action, parameters = {})
+      def post_data(_action, parameters = {})
         JSON.generate(parameters)
       end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -16,6 +16,11 @@ adyen:
   password: ''
   merchant_account: ''
 
+adyen_checkout:
+  username: ''
+  password: ''
+  merchant_account: ''
+
 allied_wallet:
   site_id: site_id
   merchant_id: merchant_id

--- a/test/remote/gateways/remote_adyen_checkout_test.rb
+++ b/test/remote/gateways/remote_adyen_checkout_test.rb
@@ -1,0 +1,178 @@
+require 'test_helper'
+
+class RemoteAdyenCheckoutTest < Test::Unit::TestCase
+  def setup
+    @gateway = AdyenCheckoutGateway.new(fixtures(:adyen_checkout))
+
+    @amount = 100
+
+    @credit_card = credit_card('4111111111111111',
+        :month => 03,
+        :year => 2030,
+        :first_name => 'John',
+        :last_name => 'Smith',
+        :verification_value => '737',
+        :brand => 'visa'
+    )
+
+    @declined_card = credit_card('4000300011112220')
+
+    @options = {
+        reference: '345123',
+        shopper_email: 'john.smith@test.com',
+        shopper_ip: '77.110.174.153',
+        shopper_reference: 'John Smith',
+        billing_address: address(),
+        order_id: '123',
+        stored_credential: {reason_type: 'unscheduled'},
+    }
+  end
+
+  def test_successful_purchase
+    response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_successful_purchase_no_cvv
+    credit_card = @credit_card
+    credit_card.verification_value = nil
+    response = @gateway.purchase(@amount, credit_card, @options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_successful_purchase_with_more_options
+    options = @options.merge!(
+        fraudOffset: '1',
+        installments: 2,
+        shopper_statement: 'statement note',
+        device_fingerprint: 'm7Cmrf++0cW4P6XfF7m/rA',
+        capture_delay_hours: 4)
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_successful_purchase_with_risk_data
+    options = @options.merge(
+        risk_data:
+            {
+                'operatingSystem' => 'HAL9000',
+                'destinationLatitude' => '77.641423',
+                'destinationLongitude' => '12.9503376'
+            }
+    )
+
+    response = @gateway.purchase(@amount, @credit_card, options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_failed_purchase
+    response = @gateway.purchase(@amount, @declined_card, @options)
+    assert_failure response
+    assert_equal 'Refused | Refused', response.message
+  end
+
+  def test_successful_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount, purchase.authorization)
+    assert_success refund
+    assert_equal '[refund-received]', refund.message
+  end
+
+  def test_partial_refund
+    purchase = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success purchase
+
+    assert refund = @gateway.refund(@amount-1, purchase.authorization)
+    assert_success refund
+    assert_equal '[refund-received]', refund.message
+  end
+
+  def test_failed_refund
+    response = @gateway.refund(@amount, '')
+    assert_failure response
+    assert_equal 'Original pspReference required for this operation', response.message
+  end
+
+  def test_successful_store
+    assert response = @gateway.store(@credit_card, @options)
+
+    assert_success response
+    assert !response.authorization.split('#')[2].nil?
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_failed_store
+    assert response = @gateway.store(@declined_card, @options)
+
+    assert_failure response
+    assert_equal 'Refused | Refused', response.message
+  end
+
+  def test_successful_purchase_using_stored_card
+    assert store_response = @gateway.store(@credit_card, @options)
+    assert_success store_response
+
+    response = @gateway.purchase(@amount, store_response.params['additionalData']['recurring.recurringDetailReference'], @options)
+    assert_success response
+    assert_equal 'Authorised', response.message
+  end
+
+  def test_invalid_login
+    gateway = AdyenCheckoutGateway.new(username: '', password: '', merchant_account: '')
+
+    response = gateway.purchase(@amount, @credit_card, @options)
+    assert_failure response
+  end
+
+  def test_transcript_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  def test_incorrect_number_for_purchase
+    card = credit_card('4242424242424241')
+    assert response = @gateway.purchase(@amount, card, @options)
+    assert_failure response
+    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_invalid_number_for_purchase
+    card = credit_card('-1')
+    assert response = @gateway.purchase(@amount, card, @options)
+    assert_failure response
+    assert_match Gateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_invalid_expiry_month_for_purchase
+    card = credit_card('4242424242424242', month: 16)
+    assert response = @gateway.purchase(@amount, card, @options)
+    assert_failure response
+    assert_equal 'Expiry Date Invalid: Expiry month should be between 1 and 12 inclusive', response.message
+  end
+
+  def test_invalid_expiry_year_for_purchase
+    card = credit_card('4242424242424242', year: 'xx')
+    assert response = @gateway.purchase(@amount, card, @options)
+    assert_failure response
+    assert response.message.include?('Expiry year should be a 4 digit number greater than')
+  end
+
+  def test_invalid_cvc_for_purchase
+    card = credit_card('4242424242424242', verification_value: -1)
+    assert response = @gateway.purchase(@amount, card, @options)
+    assert_failure response
+    assert_match Gateway::STANDARD_ERROR_CODE[:invalid_cvc], response.error_code
+  end
+end

--- a/test/unit/gateways/adyen_checkout_test.rb
+++ b/test/unit/gateways/adyen_checkout_test.rb
@@ -1,0 +1,410 @@
+require 'test_helper'
+
+class AdyenTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = AdyenCheckoutGateway.new(
+        username: 'ws@adyenmerchant.com',
+        password: 'password',
+        merchant_account: 'merchantAccount'
+    )
+
+    @credit_card = credit_card('4111111111111111',
+        :month => 8,
+        :year => 2018,
+        :first_name => 'Test',
+        :last_name => 'Card',
+        :verification_value => '737',
+        :brand => 'visa'
+    )
+
+    @elo_credit_card = credit_card('5066 9911 1111 1118',
+        :month => 10,
+        :year => 2020,
+        :first_name => 'John',
+        :last_name => 'Smith',
+        :verification_value => '737',
+        :brand => 'elo'
+    )
+
+    @unionpay_credit_card = credit_card('8171 9999 0000 0000 021',
+        :month => 10,
+        :year => 2030,
+        :first_name => 'John',
+        :last_name => 'Smith',
+        :verification_value => '737',
+        :brand => 'unionpay'
+    )
+
+    @amount = 100
+
+    @options = {
+        billing_address: address(),
+        shipping_address: address(),
+        shopper_reference: 'John Smith',
+        order_id: '345123',
+        installments: 2,
+        stored_credential: {reason_type: 'unscheduled'}
+    }
+
+    @normalized_initial_stored_credential = {
+        stored_credential: {
+            initial_transaction: true,
+            reason_type: 'unscheduled'
+        }
+    }
+
+    @normalized_stored_credential = {
+        stored_credential: {
+            initial_transaction: false,
+            reason_type: 'recurring'
+        }
+    }
+  end
+
+  def test_successful_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+    assert_equal '#7914775043909934#', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_elo_card
+    response = stub_comms do
+      @gateway.purchase(@amount, @elo_credit_card, @options)
+    end.respond_with(simple_successful_authorize_response, simple_successful_capture_repsonse)
+    assert_success response
+    assert_equal '#8835511210681145#', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_unionpay_card
+    response = stub_comms do
+      @gateway.purchase(@amount, @unionpay_credit_card, @options)
+    end.respond_with(simple_successful_authorize_response, simple_successful_capture_repsonse)
+    assert_success response
+    assert_equal '#8835511210681145#', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_maestro_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
+    end.check_request do |endpoint, data, headers|
+      if endpoint =~ /authorise/
+        assert_match(/"overwriteBrand":true/, data)
+        assert_match(/"selectedBrand":"maestro"/, data)
+      end
+    end.respond_with(successful_authorize_response, successful_capture_response)
+    assert_success response
+    assert_equal '#7914775043909934#', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    @gateway.expects(:ssl_post).returns(failed_purchase_response)
+
+    response = @gateway.purchase(@amount, credit_card('400111'), @options)
+    assert_failure response
+
+    assert_equal AdyenGateway::STANDARD_ERROR_CODE[:incorrect_number], response.error_code
+  end
+
+  def test_successful_refund
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    response = @gateway.refund(@amount, '7914775043909934')
+    assert_equal '7914775043909934#8514775559925128#', response.authorization
+    assert_equal '[refund-received]', response.message
+    assert response.test?
+  end
+
+  def test_successful_refund_with_compound_psp_reference
+    @gateway.expects(:ssl_post).returns(successful_refund_response)
+    response = @gateway.refund(@amount, '7914775043909934#8514775559000000')
+    assert_equal '8514775559000000#8514775559925128#', response.authorization
+    assert_equal '[refund-received]', response.message
+    assert response.test?
+  end
+
+  def test_failed_refund
+    @gateway.expects(:ssl_post).returns(failed_refund_response)
+    response = @gateway.refund(@amount, '')
+    assert_nil response.authorization
+    assert_equal 'Original pspReference required for this operation', response.message
+    assert_failure response
+  end
+
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card, @options)
+    end.check_request do |endpoint, data, headers|
+      assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
+    end.respond_with(successful_store_response)
+    assert_success response
+    assert_equal '#8835205392522157#8315202663743702', response.authorization
+  end
+
+  def test_failed_store
+    @gateway.expects(:ssl_post).returns(failed_store_response)
+    response = @gateway.store(@credit_card, @options)
+    assert_failure response
+    assert_equal 'Refused | Refused', response.message
+  end
+
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_scrub_network_tokenization_card
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
+  def test_add_address
+    post = {:card => {:billingAddress => {}}}
+    @options[:billing_address].delete(:address1)
+    @options[:billing_address].delete(:address2)
+    @options[:billing_address].delete(:state)
+    @options[:shipping_address].delete(:state)
+    @gateway.send(:add_address, post, @options)
+    # Billing Address
+    assert_equal 'NA', post[:billingAddress][:street]
+    assert_equal 'NA', post[:billingAddress][:houseNumberOrName]
+    assert_equal 'NA', post[:billingAddress][:stateOrProvince]
+    assert_equal @options[:billing_address][:zip], post[:billingAddress][:postalCode]
+    assert_equal @options[:billing_address][:city], post[:billingAddress][:city]
+    assert_equal @options[:billing_address][:country], post[:billingAddress][:country]
+    # Shipping Address
+    assert_equal 'NA', post[:deliveryAddress][:stateOrProvince]
+    assert_equal @options[:shipping_address][:address1], post[:deliveryAddress][:street]
+    assert_equal @options[:shipping_address][:address2], post[:deliveryAddress][:houseNumberOrName]
+    assert_equal @options[:shipping_address][:zip], post[:deliveryAddress][:postalCode]
+    assert_equal @options[:shipping_address][:city], post[:deliveryAddress][:city]
+    assert_equal @options[:shipping_address][:country], post[:deliveryAddress][:country]
+  end
+
+  private
+
+  def pre_scrubbed
+    <<-PRE_SCRUBBED
+      opening connection to pal-test.adyen.com:443...
+      opened
+      starting SSL for pal-test.adyen.com:443...
+      SSL established
+      <- "POST /pal/servlet/Payment/v18/authorise HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic d3NfMTYzMjQ1QENvbXBhbnkuRGFuaWVsYmFra2Vybmw6eXU0aD50ZlxIVEdydSU1PDhxYTVMTkxVUw==\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: pal-test.adyen.com\r\nContent-Length: 308\r\n\r\n"
+      <- "{\"merchantAccount\":\"DanielbakkernlNL\",\"reference\":\"345123\",\"amount\":{\"value\":\"100\",\"currency\":\"USD\"},\"card\":{\"expiryMonth\":8,\"expiryYear\":2018,\"holderName\":\"John Smith\",\"number\":\"4111111111111111\",\"cvc\":\"737\"},\"shopperEmail\":\"john.smith@test.com\",\"shopperIP\":\"77.110.174.153\",\"shopperReference\":\"John Smith\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 27 Oct 2016 11:37:13 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Set-Cookie: JSESSIONID=C0D66C19173B3491D862B8FDBFD72FD7.test3e; Path=/pal/; Secure; HttpOnly\r\n"
+      -> "pspReference: 8514775682339577\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "\r\n"
+      -> "50\r\n"
+      reading 80 bytes...
+      -> ""
+      -> "{\"pspReference\":\"8514775682339577\",\"resultCode\":\"Authorised\",\"authCode\":\"31845\"}"
+      read 80 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed
+    <<-POST_SCRUBBED
+      opening connection to pal-test.adyen.com:443...
+      opened
+      starting SSL for pal-test.adyen.com:443...
+      SSL established
+      <- "POST /pal/servlet/Payment/v18/authorise HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]==\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: pal-test.adyen.com\r\nContent-Length: 308\r\n\r\n"
+      <- "{\"merchantAccount\":\"DanielbakkernlNL\",\"reference\":\"345123\",\"amount\":{\"value\":\"100\",\"currency\":\"USD\"},\"card\":{\"expiryMonth\":8,\"expiryYear\":2018,\"holderName\":\"John Smith\",\"number\":\"[FILTERED]\",\"cvc\":\"[FILTERED]\"},\"shopperEmail\":\"john.smith@test.com\",\"shopperIP\":\"77.110.174.153\",\"shopperReference\":\"John Smith\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Thu, 27 Oct 2016 11:37:13 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Set-Cookie: JSESSIONID=C0D66C19173B3491D862B8FDBFD72FD7.test3e; Path=/pal/; Secure; HttpOnly\r\n"
+      -> "pspReference: 8514775682339577\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "\r\n"
+      -> "50\r\n"
+      reading 80 bytes...
+      -> ""
+      -> "{\"pspReference\":\"8514775682339577\",\"resultCode\":\"Authorised\",\"authCode\":\"31845\"}"
+      read 80 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def pre_scrubbed_network_tokenization_card
+    <<-PRE_SCRUBBED
+      opening connection to pal-test.adyen.com:443...
+      opened
+      starting SSL for pal-test.adyen.com:443...
+      SSL established
+      I, [2018-06-18T11:53:47.394267 #25363]  INFO -- : [ActiveMerchant::Billing::AdyenGateway] connection_ssl_version=TLSv1.2 connection_ssl_cipher=ECDHE-RSA-AES128-GCM-SHA256
+      D, [2018-06-18T11:53:47.394346 #25363] DEBUG -- : {"merchantAccount":"SpreedlyCOM294","reference":"123","amount":{"value":"100","currency":"USD"},"mpiData":{"authenticationResponse":"Y","cavv":"YwAAAAAABaYcCMX/OhNRQAAAAAA=","directoryResponse":"Y","eci":"07"},"card":{"expiryMonth":8,"expiryYear":2018,"holderName":"Longbob Longsen","number":"4111111111111111","billingAddress":{"street":"456 My Street","houseNumberOrName":"Apt 1","postalCode":"K1C2N6","city":"Ottawa","stateOrProvince":"ON","country":"CA"}},"shopperEmail":"john.smith@test.com","shopperIP":"77.110.174.153","shopperReference":"John Smith","selectedBrand":"applepay","shopperInteraction":"Ecommerce"}
+      <- "POST /pal/servlet/Payment/v18/authorise HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic d3NAQ29tcGFueS5TcHJlZWRseTQ3MTo3c3d6U0p2R1VWViUvP3Q0Uy9bOVtoc0hF\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: pal-test.adyen.com\r\nContent-Length: 618\r\n\r\n"
+      <- "{\"merchantAccount\":\"SpreedlyCOM294\",\"reference\":\"123\",\"amount\":{\"value\":\"100\",\"currency\":\"USD\"},\"mpiData\":{\"authenticationResponse\":\"Y\",\"cavv\":\"YwAAAAAABaYcCMX/OhNRQAAAAAA=\",\"directoryResponse\":\"Y\",\"eci\":\"07\"},\"card\":{\"expiryMonth\":8,\"expiryYear\":2018,\"holderName\":\"Longbob Longsen\",\"number\":\"4111111111111111\",\"billingAddress\":{\"street\":\"456 My Street\",\"houseNumberOrName\":\"Apt 1\",\"postalCode\":\"K1C2N6\",\"city\":\"Ottawa\",\"stateOrProvince\":\"ON\",\"country\":\"CA\"}},\"shopperEmail\":\"john.smith@test.com\",\"shopperIP\":\"77.110.174.153\",\"shopperReference\":\"John Smith\",\"selectedBrand\":\"applepay\",\"shopperInteraction\":\"Ecommerce\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 18 Jun 2018 15:53:47 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Set-Cookie: JSESSIONID=06EE78291B761A33ED9E21E46BA54649.test104e; Path=/pal; Secure; HttpOnly\r\n"
+      -> "pspReference: 8835293372276408\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "\r\n"
+      -> "50\r\n"
+      reading 80 bytes...
+      -> ""
+      -> "{\"pspReference\":\"8835293372276408\",\"resultCode\":\"Authorised\",\"authCode\":\"26056\"}"
+      read 80 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    PRE_SCRUBBED
+  end
+
+  def post_scrubbed_network_tokenization_card
+    <<-POST_SCRUBBED
+      opening connection to pal-test.adyen.com:443...
+      opened
+      starting SSL for pal-test.adyen.com:443...
+      SSL established
+      I, [2018-06-18T11:53:47.394267 #25363]  INFO -- : [ActiveMerchant::Billing::AdyenGateway] connection_ssl_version=TLSv1.2 connection_ssl_cipher=ECDHE-RSA-AES128-GCM-SHA256
+      D, [2018-06-18T11:53:47.394346 #25363] DEBUG -- : {"merchantAccount":"SpreedlyCOM294","reference":"123","amount":{"value":"100","currency":"USD"},"mpiData":{"authenticationResponse":"Y","cavv":"[FILTERED]","directoryResponse":"Y","eci":"07"},"card":{"expiryMonth":8,"expiryYear":2018,"holderName":"Longbob Longsen","number":"[FILTERED]","billingAddress":{"street":"456 My Street","houseNumberOrName":"Apt 1","postalCode":"K1C2N6","city":"Ottawa","stateOrProvince":"ON","country":"CA"}},"shopperEmail":"john.smith@test.com","shopperIP":"77.110.174.153","shopperReference":"John Smith","selectedBrand":"applepay","shopperInteraction":"Ecommerce"}
+      <- "POST /pal/servlet/Payment/v18/authorise HTTP/1.1\r\nContent-Type: application/json\r\nAuthorization: Basic [FILTERED]\r\nConnection: close\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nHost: pal-test.adyen.com\r\nContent-Length: 618\r\n\r\n"
+      <- "{\"merchantAccount\":\"SpreedlyCOM294\",\"reference\":\"123\",\"amount\":{\"value\":\"100\",\"currency\":\"USD\"},\"mpiData\":{\"authenticationResponse\":\"Y\",\"cavv\":\"[FILTERED]\",\"directoryResponse\":\"Y\",\"eci\":\"07\"},\"card\":{\"expiryMonth\":8,\"expiryYear\":2018,\"holderName\":\"Longbob Longsen\",\"number\":\"[FILTERED]\",\"billingAddress\":{\"street\":\"456 My Street\",\"houseNumberOrName\":\"Apt 1\",\"postalCode\":\"K1C2N6\",\"city\":\"Ottawa\",\"stateOrProvince\":\"ON\",\"country\":\"CA\"}},\"shopperEmail\":\"john.smith@test.com\",\"shopperIP\":\"77.110.174.153\",\"shopperReference\":\"John Smith\",\"selectedBrand\":\"applepay\",\"shopperInteraction\":\"Ecommerce\"}"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 18 Jun 2018 15:53:47 GMT\r\n"
+      -> "Server: Apache\r\n"
+      -> "Set-Cookie: JSESSIONID=06EE78291B761A33ED9E21E46BA54649.test104e; Path=/pal; Secure; HttpOnly\r\n"
+      -> "pspReference: 8835293372276408\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "Content-Type: application/json;charset=utf-8\r\n"
+      -> "\r\n"
+      -> "50\r\n"
+      reading 80 bytes...
+      -> ""
+      -> "{\"pspReference\":\"8835293372276408\",\"resultCode\":\"Authorised\",\"authCode\":\"26056\"}"
+      read 80 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    POST_SCRUBBED
+  end
+
+  def failed_purchase_response
+    <<-RESPONSE
+    {
+      "status": 422,
+      "errorCode": "101",
+      "message": "Invalid card number",
+      "errorType": "validation",
+      "pspReference": "8514775645144049"
+    }
+    RESPONSE
+  end
+
+  def simple_successful_authorize_response
+    <<-RESPONSE
+    {
+      "pspReference":"8835511210681145",
+      "resultCode":"Authorised",
+      "authCode":"98696"
+    }
+    RESPONSE
+  end
+
+  def simple_successful_capture_repsonse
+    <<-RESPONSE
+    {
+      "pspReference":"8835511210689965",
+      "response":"[capture-received]"
+    }
+    RESPONSE
+  end
+
+  def successful_authorize_response
+    <<-RESPONSE
+    {
+      "additionalData": {
+        "cvcResult": "1 Matches",
+        "avsResult": "0 Unknown",
+        "cvcResultRaw": "M"
+      },
+      "pspReference":"7914775043909934",
+      "resultCode":"Authorised",
+      "authCode":"50055"
+    }
+    RESPONSE
+  end
+
+  def successful_capture_response
+    <<-RESPONSE
+    {
+      "pspReference": "8814775564188305",
+      "response": "[capture-received]"
+    }
+    RESPONSE
+  end
+
+  def successful_refund_response
+    <<-RESPONSE
+    {
+      "pspReference": "8514775559925128",
+      "response": "[refund-received]"
+    }
+    RESPONSE
+  end
+
+  def failed_refund_response
+    <<-RESPONSE
+    {
+      "status":422,
+      "errorCode":"167",
+      "message":"Original pspReference required for this operation",
+      "errorType":"validation"
+    }
+    RESPONSE
+  end
+
+  def successful_store_response
+    <<-RESPONSE
+    {"additionalData":{"recurring.recurringDetailReference":"8315202663743702","recurring.shopperReference":"John Smith"},"pspReference":"8835205392522157","resultCode":"Authorised","authCode":"94571"}
+    RESPONSE
+  end
+
+  def failed_store_response
+    <<-RESPONSE
+    {"pspReference":"8835205393394754","refusalReason":"Refused","resultCode":"Refused"}
+    RESPONSE
+  end
+end

--- a/test/unit/gateways/adyen_checkout_test.rb
+++ b/test/unit/gateways/adyen_checkout_test.rb
@@ -140,7 +140,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_store
     response = stub_comms do
       @gateway.store(@credit_card, @options)
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |_endpoint, data, _headers|
       assert_equal 'CardOnFile', JSON.parse(data)['recurringProcessingModel']
     end.respond_with(successful_store_response)
     assert_success response

--- a/test/unit/gateways/adyen_checkout_test.rb
+++ b/test/unit/gateways/adyen_checkout_test.rb
@@ -93,7 +93,7 @@ class AdyenTest < Test::Unit::TestCase
   def test_successful_maestro_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options.merge({selected_brand: 'maestro', overwrite_brand: 'true'}))
-    end.check_request do |endpoint, data, headers|
+    end.check_request do |endpoint, data, _headers|
       if endpoint =~ /authorise/
         assert_match(/"overwriteBrand":true/, data)
         assert_match(/"selectedBrand":"maestro"/, data)


### PR DESCRIPTION
This PR implements the new checkout API that Adyen is encouraging everyone to migrate to. This implementation was made specifically with tokenizing cards in mind:

https://docs.adyen.com/checkout/tokenization/create-and-use-tokens

However the purchase method still supports one-off card purchases if full credit card details are passed.  

Unit Tests:
```
13 tests, 67 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```

Remote Tests:
```
18 tests, 50 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
```