### PR TITLE
Stored Credential for Moneris - Credential on File - PGT-63

### DIFF
--- a/lib/active_merchant/billing/gateways/moneris.rb
+++ b/lib/active_merchant/billing/gateways/moneris.rb
@@ -2,7 +2,6 @@ require 'rexml/document'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
-
     # To learn more about the Moneris gateway, please contact
     # eselectplus@moneris.com for a copy of their integration guide. For
     # information on remote testing, please see "Test Environment Penny Value
@@ -34,7 +33,7 @@ module ActiveMerchant #:nodoc:
         requires!(options, :login, :password)
         @cvv_enabled = options[:cvv_enabled]
         @avs_enabled = options[:avs_enabled]
-        options = { :crypt_type => 7 }.merge(options)
+        options[:crypt_type] = 7 unless options.has_key?(:crypt_type)
         super
       end
 
@@ -47,17 +46,18 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
         post = {}
         add_payment_source(post, creditcard_or_datakey, options)
-        post[:amount]     = amount(money)
-        post[:order_id]   = options[:order_id]
-        post[:address]    = options[:billing_address] || options[:address]
+        post[:amount] = amount(money)
+        post[:order_id] = options[:order_id]
+        post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
+        add_stored_credential(post, options)
         action = if post[:cavv]
-          'cavv_preauth'
-        elsif post[:data_key].blank?
-          'preauth'
-        else
-          'res_preauth_cc'
-        end
+                   'cavv_preauth'
+                 elsif post[:data_key].blank?
+                   'preauth'
+                 else
+                   'res_preauth_cc'
+                 end
         commit(action, post)
       end
 
@@ -69,17 +69,18 @@ module ActiveMerchant #:nodoc:
         requires!(options, :order_id)
         post = {}
         add_payment_source(post, creditcard_or_datakey, options)
-        post[:amount]     = amount(money)
-        post[:order_id]   = options[:order_id]
-        post[:address]    = options[:billing_address] || options[:address]
+        post[:amount] = amount(money)
+        post[:order_id] = options[:order_id]
+        post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
+        add_stored_credential(post, options)
         action = if post[:cavv]
-          'cavv_purchase'
-        elsif post[:data_key].blank?
-          'purchase'
-        else
-          'res_purchase_cc'
-        end
+                   'cavv_purchase'
+                 elsif post[:data_key].blank?
+                   'purchase'
+                 else
+                   'res_purchase_cc'
+                 end
         commit(action, post)
       end
 
@@ -91,7 +92,7 @@ module ActiveMerchant #:nodoc:
       # gateways the two numbers are concatenated together with a ; separator as
       # the authorization number returned by authorization
       def capture(money, authorization, options = {})
-        commit 'completion', crediting_params(authorization, :comp_amount => amount(money))
+        commit 'completion', crediting_params(authorization, comp_amount: amount(money))
       end
 
       # Voiding requires the original transaction ID and order ID of some open
@@ -129,22 +130,43 @@ module ActiveMerchant #:nodoc:
       end
 
       def refund(money, authorization, options = {})
-        commit 'refund', crediting_params(authorization, :amount => amount(money))
+        commit 'refund', crediting_params(authorization, amount: amount(money))
       end
 
       def verify(credit_card, options={})
-        MultiResponse.run(:use_first_response) do |r|
-          r.process { authorize(100, credit_card, options) }
-          r.process(:ignore_result) { void(r.authorization, options) }
-        end
+        requires!(options, :order_id)
+        post = {}
+        add_payment_source(post, credit_card, options)
+        post[:order_id] = options[:order_id]
+        post[:address] = options[:billing_address] || options[:address]
+        post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
+        add_stored_credential(post, options)
+        action = if post[:data_key].blank?
+                   'card_verification'
+                 else
+                   'res_card_verification_cc'
+                 end
+        commit(action, post)
       end
 
+      # When passing a :duration option (time in seconds) you can create a
+      # temporary vault record to avoid incurring Moneris vault storage fees
+      #
+      # https://developer.moneris.com/Documentation/NA/E-Commerce%20Solutions/API/Vault#vaulttokenadd
       def store(credit_card, options = {})
         post = {}
         post[:pan] = credit_card.number
         post[:expdate] = expdate(credit_card)
+        post[:address] = options[:billing_address] || options[:address]
         post[:crypt_type] = options[:crypt_type] || @options[:crypt_type]
-        commit('res_add_cc', post)
+        add_stored_credential(post, options)
+
+        if options[:duration]
+          post[:duration] = options[:duration]
+          commit('res_temp_add', post)
+        else
+          commit('res_add_cc', post)
+        end
       end
 
       def unstore(data_key, options = {})
@@ -162,36 +184,100 @@ module ActiveMerchant #:nodoc:
         commit('res_update_cc', post)
       end
 
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<store_id>).+(</store_id>)), '\1[FILTERED]\2').
+          gsub(%r((<api_token>).+(</api_token>)), '\1[FILTERED]\2').
+          gsub(%r((<pan>).+(</pan>)), '\1[FILTERED]\2').
+          gsub(%r((<cvd_value>).+(</cvd_value>)), '\1[FILTERED]\2').
+          gsub(%r((<cavv>).+(</cavv>)), '\1[FILTERED]\2')
+      end
+
       private # :nodoc: all
 
       def expdate(creditcard)
-        sprintf("%.4i", creditcard.year)[-2..-1] + sprintf("%.2i", creditcard.month)
+        sprintf('%.4i', creditcard.year)[-2..-1] + sprintf('%.2i', creditcard.month)
       end
 
-      def add_payment_source(post, source, options)
-        if source.is_a?(String)
-          post[:data_key]   = source
-          post[:cust_id]    = options[:customer]
+      def add_payment_source(post, payment_method, options)
+        if payment_method.is_a?(String)
+          post[:data_key] = payment_method
+          post[:cust_id] = options[:customer]
         else
-          if source.respond_to?(:track_data) && source.track_data.present?
-            post[:pos_code]   = '00'
-            post[:track2]     = source.track_data
+          if payment_method.respond_to?(:track_data) && payment_method.track_data.present?
+            post[:pos_code] = '00'
+            post[:track2] = payment_method.track_data
           else
-            post[:pan]        = source.number
-            post[:expdate]    = expdate(source)
-            post[:cvd_value]  = source.verification_value if source.verification_value?
-            post[:cavv] = source.payment_cryptogram if source.is_a?(NetworkTokenizationCreditCard)
+            post[:pan] = payment_method.number
+            post[:expdate] = expdate(payment_method)
+            post[:cvd_value] = payment_method.verification_value if payment_method.verification_value?
+            post[:cavv] = payment_method.payment_cryptogram if payment_method.is_a?(NetworkTokenizationCreditCard)
+            post[:wallet_indicator] = wallet_indicator(payment_method.source.to_s) if payment_method.is_a?(NetworkTokenizationCreditCard)
+            post[:crypt_type] = (payment_method.eci || 7) if payment_method.is_a?(NetworkTokenizationCreditCard)
           end
-          post[:cust_id] = options[:customer] || source.name
+          post[:cust_id] = options[:customer] || payment_method.name
+        end
+      end
+
+      def add_cof(post, options)
+        post[:issuer_id] = options[:issuer_id] if options[:issuer_id]
+        post[:payment_indicator] = options[:payment_indicator] if options[:payment_indicator]
+        post[:payment_information] = options[:payment_information] if options[:payment_information]
+      end
+
+      def add_stored_credential(post, options)
+        add_cof(post, options)
+        # if any of :issuer_id, :payment_information, or :payment_indicator is not passed,
+        # then check for :stored credential options
+        return unless (stored_credential = options[:stored_credential]) && !cof_details_present?(options)
+
+        if stored_credential[:initial_transaction]
+          add_stored_credential_initial(post, options)
+        else
+          add_stored_credential_used(post, options)
+        end
+      end
+
+      def add_stored_credential_initial(post, options)
+        post[:payment_information] ||= '0'
+        post[:issuer_id] ||= ''
+        if options[:stored_credential][:initiator] == 'merchant'
+          case options[:stored_credential][:reason_type]
+          when 'recurring', 'installment'
+            post[:payment_indicator] ||= 'R'
+          when 'unscheduled'
+            post[:payment_indicator] ||= 'C'
+          end
+        else
+          post[:payment_indicator] ||= 'C'
+        end
+      end
+
+      def add_stored_credential_used(post, options)
+        post[:payment_information] ||= '2'
+        post[:issuer_id] = options[:stored_credential][:network_transaction_id] if options[:issuer_id].blank?
+        if options[:stored_credential][:initiator] == 'merchant'
+          case options[:stored_credential][:reason_type]
+          when 'recurring', 'installment'
+            post[:payment_indicator] ||= 'R'
+          when '', 'unscheduled'
+            post[:payment_indicator] ||= 'U'
+          end
+        else
+          post[:payment_indicator] ||= 'Z'
         end
       end
 
       # Common params used amongst the +credit+, +void+ and +capture+ methods
       def crediting_params(authorization, options = {})
         {
-          :txn_number => split_authorization(authorization).first,
-          :order_id   => split_authorization(authorization).last,
-          :crypt_type => options[:crypt_type] || @options[:crypt_type]
+          txn_number: split_authorization(authorization).first,
+          order_id: split_authorization(authorization).last,
+          crypt_type: options[:crypt_type] || @options[:crypt_type]
         }.merge(options)
       end
 
@@ -211,30 +297,30 @@ module ActiveMerchant #:nodoc:
         raw = ssl_post(url, data)
         response = parse(raw)
 
-        Response.new(successful?(response), message_from(response[:message]), response,
-          :test          => test?,
-          :avs_result    => { :code => response[:avs_result_code] },
-          :cvv_result    => response[:cvd_result_code] && response[:cvd_result_code][-1,1],
-          :authorization => authorization_from(response)
-        )
+        Response.new(
+          successful?(response),
+          message_from(response[:message]),
+          response,
+          test: test?,
+          avs_result: {code: response[:avs_result_code]},
+          cvv_result: response[:cvd_result_code] && response[:cvd_result_code][-1, 1],
+          authorization: authorization_from(response))
       end
 
       # Generates a Moneris authorization string of the form 'trans_id;receipt_id'.
       def authorization_from(response = {})
-        if response[:trans_id] && response[:receipt_id]
-          "#{response[:trans_id]};#{response[:receipt_id]}"
-        end
+        "#{response[:trans_id]};#{response[:receipt_id]}" if response[:trans_id] && response[:receipt_id]
       end
 
       # Tests for a successful response from Moneris' servers
       def successful?(response)
         response[:response_code] &&
-        response[:complete] &&
-        (0..49).include?(response[:response_code].to_i)
+          response[:complete] &&
+          (0..49).cover?(response[:response_code].to_i)
       end
 
       def parse(xml)
-        response = { :message => "Global Error Receipt", :complete => false }
+        response = { message: 'Global Error Receipt', complete: false }
         hashify_xml!(xml, response)
         response
       end
@@ -242,16 +328,17 @@ module ActiveMerchant #:nodoc:
       def hashify_xml!(xml, response)
         xml = REXML::Document.new(xml)
         return if xml.root.nil?
+
         xml.elements.each('//receipt/*') do |node|
           response[node.name.underscore.to_sym] = normalize(node.text)
         end
       end
 
       def post_data(action, parameters = {})
-        xml   = REXML::Document.new
-        root  = xml.add_element("request")
-        root.add_element("store_id").text  = options[:login]
-        root.add_element("api_token").text = options[:password]
+        xml = REXML::Document.new
+        root = xml.add_element('request')
+        root.add_element('store_id').text = options[:login]
+        root.add_element('api_token').text = options[:password]
         root.add_element(transaction_element(action, parameters))
 
         xml.to_s
@@ -267,6 +354,8 @@ module ActiveMerchant #:nodoc:
             transaction.add_element(avs_element(parameters[:address])) if @avs_enabled && parameters[:address]
           when :cvd_info
             transaction.add_element(cvd_element(parameters[:cvd_value])) if @cvv_enabled
+          when :cof_info
+            transaction.add_element(credential_on_file(parameters)) if cof_details_present?(parameters)
           else
             transaction.add_element(key.to_s).text = parameters[key] unless parameters[key].blank?
           end
@@ -280,8 +369,8 @@ module ActiveMerchant #:nodoc:
         tokens = full_address.split(/\s+/)
 
         element = REXML::Element.new('avs_info')
-        element.add_element('avs_street_number').text = tokens.select{|x| x =~ /\d/}.join(' ')
-        element.add_element('avs_street_name').text = tokens.reject{|x| x =~ /\d/}.join(' ')
+        element.add_element('avs_street_number').text = tokens.select { |x| x =~ /\d/ }.join(' ')
+        element.add_element('avs_street_name').text = tokens.reject { |x| x =~ /\d/ }.join(' ')
         element.add_element('avs_zipcode').text = address[:zip]
         element
       end
@@ -289,39 +378,66 @@ module ActiveMerchant #:nodoc:
       def cvd_element(cvd_value)
         element = REXML::Element.new('cvd_info')
         if cvd_value
-          element.add_element('cvd_indicator').text = "1"
+          element.add_element('cvd_indicator').text = '1'
           element.add_element('cvd_value').text = cvd_value
         else
-          element.add_element('cvd_indicator').text = "0"
+          element.add_element('cvd_indicator').text = '0'
         end
         element
       end
 
+      def cof_details_present?(parameters)
+        parameters[:issuer_id] && parameters[:payment_indicator] && parameters[:payment_information]
+      end
+
+      def credential_on_file(parameters)
+        issuer_id = parameters[:issuer_id]
+        payment_indicator = parameters[:payment_indicator]
+        payment_information = parameters[:payment_information]
+
+        cof_info = REXML::Element.new('cof_info')
+        cof_info.add_element('issuer_id').text = issuer_id
+        cof_info.add_element('payment_indicator').text = payment_indicator
+        cof_info.add_element('payment_information').text = payment_information
+        cof_info
+      end
+
+      def wallet_indicator(token_source)
+        return 'APP' if token_source == 'apple_pay'
+        return 'ANP' if token_source == 'android_pay'
+
+        nil
+      end
+
       def message_from(message)
         return 'Unspecified error' if message.blank?
-        message.gsub(/[^\w]/, ' ').split.join(" ").capitalize
+
+        message.gsub(/[^\w]/, ' ').split.join(' ').capitalize
       end
 
       def actions
         {
-          "purchase"           => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code],
-          "preauth"            => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code],
-          "command"            => [:order_id],
-          "refund"             => [:order_id, :amount, :txn_number, :crypt_type],
-          "indrefund"          => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type],
-          "completion"         => [:order_id, :comp_amount, :txn_number, :crypt_type],
-          "purchasecorrection" => [:order_id, :txn_number, :crypt_type],
-          "cavv_preauth"       => [:order_id, :cust_id, :amount, :pan, :expdate, :cavv],
-          "cavv_purchase"      => [:order_id, :cust_id, :amount, :pan, :expdate, :cavv],
-          "transact"           => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type],
-          "Batchcloseall"      => [],
-          "opentotals"         => [:ecr_number],
-          "batchclose"         => [:ecr_number],
-          "res_add_cc"         => [:pan, :expdate, :crypt_type],
-          "res_delete"         => [:data_key],
-          "res_update_cc"      => [:data_key, :pan, :expdate, :crypt_type],
-          "res_purchase_cc"    => [:data_key, :order_id, :cust_id, :amount, :crypt_type],
-          "res_preauth_cc"     => [:data_key, :order_id, :cust_id, :amount, :crypt_type]
+          'purchase' => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code, :cof_info],
+          'preauth' => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :track2, :pos_code, :cof_info],
+          'command' => [:order_id],
+          'refund' => [:order_id, :amount, :txn_number, :crypt_type],
+          'indrefund' => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type],
+          'completion' => [:order_id, :comp_amount, :txn_number, :crypt_type],
+          'purchasecorrection' => [:order_id, :txn_number, :crypt_type],
+          'cavv_preauth' => [:order_id, :cust_id, :amount, :pan, :expdate, :cavv, :crypt_type, :wallet_indicator],
+          'cavv_purchase' => [:order_id, :cust_id, :amount, :pan, :expdate, :cavv, :crypt_type, :wallet_indicator],
+          'card_verification' => [:order_id, :cust_id, :pan, :expdate, :crypt_type, :avs_info, :cvd_info, :cof_info],
+          'transact' => [:order_id, :cust_id, :amount, :pan, :expdate, :crypt_type],
+          'Batchcloseall' => [],
+          'opentotals' => [:ecr_number],
+          'batchclose' => [:ecr_number],
+          'res_add_cc' => [:pan, :expdate, :crypt_type, :avs_info, :cof_info],
+          'res_temp_add' => [:pan, :expdate, :crypt_type, :duration],
+          'res_delete' => [:data_key],
+          'res_update_cc' => [:data_key, :pan, :expdate, :crypt_type, :avs_info, :cof_info],
+          'res_purchase_cc' => [:data_key, :order_id, :cust_id, :amount, :crypt_type, :cof_info],
+          'res_preauth_cc' => [:data_key, :order_id, :cust_id, :amount, :crypt_type, :cof_info],
+          'res_card_verification_cc' => [:order_id, :data_key, :expdate, :crypt_type, :cof_info]
         }
       end
     end

--- a/test/remote/gateways/remote_moneris_test.rb
+++ b/test/remote/gateways/remote_moneris_test.rb
@@ -6,11 +6,11 @@ class MonerisRemoteTest < Test::Unit::TestCase
 
     @gateway = MonerisGateway.new(fixtures(:moneris))
     @amount = 100
-    @credit_card = credit_card('4242424242424242')
+    @credit_card = credit_card('4242424242424242', :verification_value => '012')
     @options = {
-      :order_id => generate_unique_id,
-      :customer => generate_unique_id,
-      :billing_address => address
+        :order_id => generate_unique_id,
+        :customer => generate_unique_id,
+        :billing_address => address
     }
   end
 
@@ -21,10 +21,80 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert_false response.authorization.blank?
   end
 
+  def test_successful_first_purchase_with_credential_on_file
+    gateway = MonerisGateway.new(fixtures(:moneris))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: '', payment_indicator: 'C', payment_information: '0'))
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+    assert_not_empty response.params['issuer_id']
+  end
+
+  def test_successful_purchase_with_cof_enabled_and_no_cof_options
+    gateway = MonerisGateway.new(fixtures(:moneris))
+    assert response = gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_non_cof_purchase_with_cof_enabled_and_only_issuer_id_sent
+    gateway = MonerisGateway.new(fixtures(:moneris))
+    assert response = gateway.purchase(@amount, @credit_card, @options.merge(issuer_id: ''))
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+    assert_nil response.params['issuer_id']
+  end
+
+  def test_successful_subsequent_purchase_with_credential_on_file
+    gateway = MonerisGateway.new(fixtures(:moneris))
+    assert response = gateway.authorize(
+      @amount,
+      @credit_card,
+      @options.merge(
+        issuer_id: '',
+        payment_indicator: 'C',
+        payment_information: '0'
+      )
+    )
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+
+    assert response2 = gateway.purchase(
+      @amount,
+      @credit_card,
+      @options.merge(
+        order_id: response.authorization,
+        issuer_id: response.params['issuer_id'],
+        payment_indicator: 'U',
+        payment_information: '2'
+      )
+    )
+    assert_success response2
+    assert_equal 'Approved', response2.message
+    assert_false response2.authorization.blank?
+  end
+
   def test_successful_purchase_with_network_tokenization
-    @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "BwABB4JRdgAAAAAAiFF2AAAAAAA=",
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: nil
+    )
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+  end
+
+  def test_successful_purchase_with_network_tokenization_apple_pay_source
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
+      verification_value: nil,
+      source: :apple_pay
     )
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
@@ -74,8 +144,9 @@ class MonerisRemoteTest < Test::Unit::TestCase
   end
 
   def test_successful_authorization_with_network_tokenization
-    @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "BwABB4JRdgAAAAAAiFF2AAAAAAA=",
+    @credit_card = network_tokenization_credit_card(
+      '4242424242424242',
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: nil
     )
     assert response = @gateway.authorize(@amount, @credit_card, @options)
@@ -117,38 +188,38 @@ class MonerisRemoteTest < Test::Unit::TestCase
   def test_successful_verify
     response = @gateway.verify(@credit_card, @options)
     assert_success response
-    assert_match "Approved", response.message
+    assert_match 'Approved', response.message
   end
 
   def test_successful_store
     assert response = @gateway.store(@credit_card)
     assert_success response
-    assert_equal "Successfully registered cc details", response.message
-    assert response.params["data_key"].present?
-    @data_key = response.params["data_key"]
+    assert_equal 'Successfully registered cc details', response.message
+    assert response.params['data_key'].present?
+    @data_key = response.params['data_key']
   end
 
   def test_successful_unstore
     test_successful_store
     assert response = @gateway.unstore(@data_key)
     assert_success response
-    assert_equal "Successfully deleted cc details", response.message
-    assert response.params["data_key"].present?
+    assert_equal 'Successfully deleted cc details', response.message
+    assert response.params['data_key'].present?
   end
 
   def test_update
     test_successful_store
     assert response = @gateway.update(@data_key, @credit_card)
     assert_success response
-    assert_equal "Successfully updated cc details", response.message
-    assert response.params["data_key"].present?
+    assert_equal 'Successfully updated cc details', response.message
+    assert response.params['data_key'].present?
   end
 
   def test_successful_purchase_with_vault
     test_successful_store
     assert response = @gateway.purchase(@amount, @data_key, @options)
     assert_success response
-    assert_equal "Approved", response.message
+    assert_equal 'Approved', response.message
     assert_false response.authorization.blank?
   end
 
@@ -190,10 +261,10 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert response = gateway.purchase(1010, @credit_card, @options)
     assert_success response
     assert_equal(response.avs_result, {
-      'code' => 'A',
-      'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
-      'street_match' => 'Y',
-      'postal_match' => 'N'
+        'code' => 'A',
+        'message' => 'Street address matches, but 5-digit and 9-digit postal code do not match.',
+        'street_match' => 'Y',
+        'postal_match' => 'N'
     })
   end
 
@@ -203,10 +274,10 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert response = gateway.purchase(1010, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     assert_success response
     assert_equal(response.avs_result, {
-      'code' => nil,
-      'message' => nil,
-      'street_match' => nil,
-      'postal_match' => nil
+        'code' => nil,
+        'message' => nil,
+        'street_match' => nil,
+        'postal_match' => nil
     })
   end
 
@@ -214,10 +285,148 @@ class MonerisRemoteTest < Test::Unit::TestCase
     assert response = @gateway.purchase(@amount, @credit_card, @options)
     assert_success response
     assert_equal(response.avs_result, {
-      'code' => nil,
-      'message' => nil,
-      'street_match' => nil,
-      'postal_match' => nil
+        'code' => nil,
+        'message' => nil,
+        'street_match' => nil,
+        'postal_match' => nil
     })
+  end
+
+  def test_purchase_using_stored_credential_recurring_cit
+    initial_options = stored_credential_options(:cardholder, :recurring, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:recurring, :cardholder, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_purchase_using_stored_credential_recurring_mit
+    initial_options = stored_credential_options(:merchant, :recurring, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:merchant, :recurring, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_purchase_using_stored_credential_installment_cit
+    initial_options = stored_credential_options(:cardholder, :installment, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:installment, :cardholder, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_purchase_using_stored_credential_installment_mit
+    initial_options = stored_credential_options(:merchant, :installment, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:merchant, :installment, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_purchase_using_stored_credential_unscheduled_cit
+    initial_options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:unscheduled, :cardholder, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_purchase_using_stored_credential_unscheduled_mit
+    initial_options = stored_credential_options(:merchant, :unscheduled, :initial)
+    assert purchase = @gateway.purchase(@amount, @credit_card, initial_options)
+    assert_success purchase
+    assert network_transaction_id = purchase.params['issuer_id']
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+
+    used_options = stored_credential_options(:merchant, :unscheduled, id: network_transaction_id)
+    assert purchase = @gateway.purchase(@amount, @credit_card, used_options)
+    assert_success purchase
+    assert_equal 'Approved', purchase.message
+    assert_false purchase.authorization.blank?
+    assert_not_empty purchase.params['issuer_id']
+  end
+
+  def test_authorize_and_capture_with_stored_credential
+    initial_options = stored_credential_options(:cardholder, :recurring, :initial)
+    assert authorization = @gateway.authorize(@amount, @credit_card, initial_options)
+    assert_success authorization
+    assert network_transaction_id = authorization.params['issuer_id']
+    assert_equal 'Approved', authorization.message
+    assert_not_empty authorization.params['issuer_id']
+
+    assert capture = @gateway.capture(@amount, authorization.authorization)
+    assert_success capture
+
+    used_options = stored_credential_options(:cardholder, :recurring, id: network_transaction_id)
+    assert authorization = @gateway.authorize(@amount, @credit_card, used_options)
+    assert_success authorization
+    assert @gateway.capture(@amount, authorization.authorization)
+  end
+
+  def test_purchase_scrubbing
+    transcript = capture_transcript(@gateway) do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end
+    transcript = @gateway.scrub(transcript)
+
+    assert_scrubbed(@credit_card.number, transcript)
+    assert_scrubbed(@credit_card.verification_value, transcript)
+    assert_scrubbed(@gateway.options[:password], transcript)
+  end
+
+  private
+
+  def stored_credential_options(*args, id: nil)
+    @options.merge(order_id: generate_unique_id,
+                   stored_credential: stored_credential(*args, id: id),
+                   issuer_id: '')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -232,6 +232,36 @@ module ActiveMerchant
       }.update(options)
     end
 
+    def statement_address(options = {})
+      {
+        address1: '456 My Street',
+        address2: 'Apt 1',
+        city:     'Ottawa',
+        state:    'ON',
+        zip:      'K1C2N6'
+      }.update(options)
+    end
+
+    def stored_credential(*args, **options)
+      id = options.delete(:id) || options.delete(:network_transaction_id)
+
+      stored_credential = {
+        network_transaction_id: id,
+        initial_transaction: false
+      }
+
+      stored_credential[:initial_transaction] = true if args.include?(:initial)
+
+      stored_credential[:reason_type] = 'recurring' if args.include?(:recurring)
+      stored_credential[:reason_type] = 'unscheduled' if args.include?(:unscheduled)
+      stored_credential[:reason_type] = 'installment' if args.include?(:installment)
+
+      stored_credential[:initiator] = 'cardholder' if args.include?(:cardholder)
+      stored_credential[:initiator] = 'merchant' if args.include?(:merchant)
+
+      stored_credential
+    end
+
     def generate_unique_id
       SecureRandom.hex(16)
     end

--- a/test/unit/gateways/moneris_test.rb
+++ b/test/unit/gateways/moneris_test.rb
@@ -7,7 +7,7 @@ class MonerisTest < Test::Unit::TestCase
     Base.mode = :test
 
     @gateway = MonerisGateway.new(
-      :login => 'store1',
+      :login => 'store3',
       :password => 'yesguy'
     )
 
@@ -18,8 +18,8 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_default_options
     assert_equal 7, @gateway.options[:crypt_type]
-    assert_equal "store1", @gateway.options[:login]
-    assert_equal "yesguy", @gateway.options[:password]
+    assert_equal 'store3', @gateway.options[:login]
+    assert_equal 'yesguy', @gateway.options[:password]
   end
 
   def test_successful_purchase
@@ -30,10 +30,67 @@ class MonerisTest < Test::Unit::TestCase
     assert_equal '58-0_3;1026.1', response.authorization
   end
 
+  def test_successful_first_purchase_with_credential_on_file
+    gateway = MonerisGateway.new(
+      :login => 'store3',
+      :password => 'yesguy'
+    )
+    gateway.expects(:ssl_post).returns(successful_first_cof_purchase_response)
+    assert response = gateway.purchase(
+      @amount,
+      @credit_card,
+      @options.merge(
+        issuer_id: '',
+        payment_indicator: 'C',
+        payment_information: '0'
+      )
+    )
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+    assert_not_empty response.params['issuer_id']
+  end
+
+  def test_successful_subsequent_purchase_with_credential_on_file
+    gateway = MonerisGateway.new(
+      :login => 'store3',
+      :password => 'yesguy'
+    )
+    gateway.expects(:ssl_post).returns(successful_first_cof_authorize_response)
+    assert response = gateway.authorize(
+      @amount,
+      @credit_card,
+      @options.merge(
+        issuer_id: '',
+        payment_indicator: 'C',
+        payment_information: '0'
+      )
+    )
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_false response.authorization.blank?
+
+    gateway.expects(:ssl_post).returns(successful_subsequent_cof_purchase_response)
+
+    assert response2 = gateway.purchase(
+      @amount,
+      @credit_card,
+      @options.merge(
+        order_id: response.authorization,
+        issuer_id: response.params['issuer_id'],
+        payment_indicator: 'U',
+        payment_information: '2'
+      )
+    )
+    assert_success response2
+    assert_equal 'Approved', response2.message
+    assert_false response2.authorization.blank?
+  end
+
   def test_successful_purchase_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_purchase_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "BwABB4JRdgAAAAAAiFF2AAAAAAA=",
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: nil
     )
     assert response = @gateway.purchase(100, @credit_card, @options)
@@ -49,67 +106,67 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_deprecated_credit
-    @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns("")
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns('')
     @gateway.expects(:parse).returns({})
     assert_deprecation_warning(Gateway::CREDIT_DEPRECATION_MESSAGE) do
-      @gateway.credit(@amount, "123;456", @options)
+      @gateway.credit(@amount, '123;456', @options)
     end
   end
 
   def test_refund
-    @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns("")
+    @gateway.expects(:ssl_post).with(anything, regexp_matches(/txn_number>123<\//), anything).returns('')
     @gateway.expects(:parse).returns({})
-    @gateway.refund(@amount, "123;456", @options)
+    @gateway.refund(@amount, '123;456', @options)
   end
 
   def test_amount_style
-   assert_equal '10.34', @gateway.send(:amount, 1034)
+    assert_equal '10.34', @gateway.send(:amount, 1034)
 
-   assert_raise(ArgumentError) do
-     @gateway.send(:amount, '10.34')
-   end
+    assert_raise(ArgumentError) do
+      @gateway.send(:amount, '10.34')
+    end
   end
 
   def test_preauth_is_valid_xml
-   params = {
-     :order_id => "order1",
-     :amount => "1.01",
-     :pan => "4242424242424242",
-     :expdate => "0303",
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_purchase_is_valid_xml
-   params = {
-     :order_id => "order1",
-     :amount => "1.01",
-     :pan => "4242424242424242",
-     :expdate => "0303",
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'purchase', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_purchase_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'purchase', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_purchase_fixture.size, data.size
   end
 
   def test_capture_is_valid_xml
-   params = {
-     :order_id => "order1",
-     :amount => "1.01",
-     :pan => "4242424242424242",
-     :expdate => "0303",
-     :crypt_type => 7,
-   }
+    params = {
+      :order_id => 'order1',
+      :amount => '1.01',
+      :pan => '4242424242424242',
+      :expdate => '0303',
+      :crypt_type => 7,
+    }
 
-   assert data = @gateway.send(:post_data, 'preauth', params)
-   assert REXML::Document.new(data)
-   assert_equal xml_capture_fixture.size, data.size
+    assert data = @gateway.send(:post_data, 'preauth', params)
+    assert REXML::Document.new(data)
+    assert_equal xml_capture_fixture.size, data.size
   end
 
   def test_successful_verify
@@ -117,7 +174,7 @@ class MonerisTest < Test::Unit::TestCase
       @gateway.verify(@credit_card, @options)
     end.respond_with(successful_authorize_response, failed_void_response)
     assert_success response
-    assert_equal "Approved", response.message
+    assert_equal 'Approved', response.message
   end
 
   def test_supported_countries
@@ -138,9 +195,9 @@ class MonerisTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_store_response)
     assert response = @gateway.store(@credit_card)
     assert_success response
-    assert_equal "Successfully registered cc details", response.message
-    assert response.params["data_key"].present?
-    @data_key = response.params["data_key"]
+    assert_equal 'Successfully registered cc details', response.message
+    assert response.params['data_key'].present?
+    @data_key = response.params['data_key']
   end
 
   def test_successful_unstore
@@ -148,8 +205,8 @@ class MonerisTest < Test::Unit::TestCase
     test_successful_store
     assert response = @gateway.unstore(@data_key)
     assert_success response
-    assert_equal "Successfully deleted cc details", response.message
-    assert response.params["data_key"].present?
+    assert_equal 'Successfully deleted cc details', response.message
+    assert response.params['data_key'].present?
   end
 
   def test_update
@@ -157,8 +214,8 @@ class MonerisTest < Test::Unit::TestCase
     test_successful_store
     assert response = @gateway.update(@data_key, @credit_card)
     assert_success response
-    assert_equal "Successfully updated cc details", response.message
-    assert response.params["data_key"].present?
+    assert_equal 'Successfully updated cc details', response.message
+    assert response.params['data_key'].present?
   end
 
   def test_successful_purchase_with_vault
@@ -166,14 +223,14 @@ class MonerisTest < Test::Unit::TestCase
     test_successful_store
     assert response = @gateway.purchase(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
     assert_success response
-    assert_equal "Approved", response.message
+    assert_equal 'Approved', response.message
     assert response.authorization.present?
   end
 
   def test_successful_authorize_with_network_tokenization
     @gateway.expects(:ssl_post).returns(successful_authorization_network_tokenization)
     @credit_card = network_tokenization_credit_card('4242424242424242',
-      payment_cryptogram: "BwABB4JRdgAAAAAAiFF2AAAAAAA=",
+      payment_cryptogram: 'BwABB4JRdgAAAAAAiFF2AAAAAAA=',
       verification_value: nil
     )
     assert response = @gateway.authorize(100, @credit_card, @options)
@@ -186,7 +243,7 @@ class MonerisTest < Test::Unit::TestCase
     test_successful_store
     assert response = @gateway.authorize(100, @data_key, {:order_id => generate_unique_id, :customer => generate_unique_id})
     assert_success response
-    assert_equal "Approved", response.message
+    assert_equal 'Approved', response.message
     assert response.authorization.present?
   end
 
@@ -200,7 +257,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_cvv_enabled_and_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
-    @credit_card.verification_value = "452"
+    @credit_card.verification_value = '452'
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -212,7 +269,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_cvv_enabled_but_not_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', cvv_enabled: true)
 
-    @credit_card.verification_value = ""
+    @credit_card.verification_value = ''
     stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -222,7 +279,7 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_cvv_disabled_and_provided
-    @credit_card.verification_value = "452"
+    @credit_card.verification_value = '452'
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -232,7 +289,7 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_cvv_disabled_but_not_provided
-    @credit_card.verification_value = ""
+    @credit_card.verification_value = ''
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
@@ -244,9 +301,9 @@ class MonerisTest < Test::Unit::TestCase
   def test_avs_enabled_and_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
-    billing_address = address(address1: "1234 Anystreet", address2: "")
-    stub_comms do
-      gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: "1")
+    billing_address = address(address1: '1234 Anystreet', address2: '')
+    stub_comms(gateway) do
+      gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: '1')
     end.check_request do |endpoint, data, headers|
       assert_match(%r{avs_street_number>1234<}, data)
       assert_match(%r{avs_street_name>Anystreet<}, data)
@@ -257,7 +314,7 @@ class MonerisTest < Test::Unit::TestCase
   def test_avs_enabled_but_not_provided
     gateway = MonerisGateway.new(login: 'store1', password: 'yesguy', avs_enabled: true)
 
-    stub_comms do
+    stub_comms(gateway) do
       gateway.purchase(@amount, @credit_card, @options.tap { |x| x.delete(:billing_address) })
     end.check_request do |endpoint, data, headers|
       assert_no_match(%r{avs_street_number>}, data)
@@ -267,9 +324,9 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def test_avs_disabled_and_provided
-    billing_address = address(address1: "1234 Anystreet", address2: "")
+    billing_address = address(address1: '1234 Anystreet', address2: '')
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: "1")
+      @gateway.purchase(@amount, @credit_card, billing_address: billing_address, order_id: '1')
     end.check_request do |endpoint, data, headers|
       assert_no_match(%r{avs_street_number>}, data)
       assert_no_match(%r{avs_street_name>}, data)
@@ -300,7 +357,7 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_customer_can_be_specified
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, order_id: "3", customer: "Joe Jones")
+      @gateway.purchase(@amount, @credit_card, order_id: '3', customer: 'Joe Jones')
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cust_id>Joe Jones}, data)
     end.respond_with(successful_purchase_response)
@@ -308,24 +365,212 @@ class MonerisTest < Test::Unit::TestCase
 
   def test_customer_not_specified_card_name_used
     stub_comms do
-      @gateway.purchase(@amount, @credit_card, order_id: "3")
+      @gateway.purchase(@amount, @credit_card, order_id: '3')
     end.check_request do |endpoint, data, headers|
       assert_match(%r{cust_id>Longbob Longsen}, data)
     end.respond_with(successful_purchase_response)
   end
 
   def test_add_swipe_data_with_creditcard
-    @credit_card.track_data = "Track Data"
+    @credit_card.track_data = 'Track Data'
 
     stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |endpoint, data, headers|
-      assert_match "<pos_code>00</pos_code>", data
-      assert_match "<track2>Track Data</track2>", data
+      assert_match '<pos_code>00</pos_code>', data
+      assert_match '<track2>Track Data</track2>', data
     end.respond_with(successful_purchase_response)
   end
 
+  def test_scrub
+    assert_equal @gateway.scrub(pre_scrub), post_scrub
+  end
+
+  def test_supports_scrubbing?
+    assert @gateway.supports_scrubbing?
+  end
+
+  def test_stored_credential_recurring_cit_initial
+    options = stored_credential_options(:cardholder, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_cit_used
+    options = stored_credential_options(:cardholder, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_initial
+    options = stored_credential_options(:merchant, :recurring, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_mit_used
+    options = stored_credential_options(:merchant, :recurring, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_initial
+    options = stored_credential_options(:cardholder, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_cit_used
+    options = stored_credential_options(:cardholder, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_initial
+    options = stored_credential_options(:merchant, :installment, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_mit_used
+    options = stored_credential_options(:merchant, :installment, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_initial
+    options = stored_credential_options(:cardholder, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_cit_used
+    options = stored_credential_options(:cardholder, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>Z<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_initial
+    options = stored_credential_options(:merchant, :unscheduled, :initial)
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id><\/issuer_id>/, data)
+      assert_match(/<payment_indicator>C<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_stored_credential_unscheduled_mit_used
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>abc123<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>U<\/payment_indicator>/, data)
+      assert_match(/<payment_information>2<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
+  def test_add_cof_overrides_stored_credential_option
+    options = stored_credential_options(:merchant, :unscheduled, id: 'abc123').merge(issuer_id: 'xyz987', payment_indicator: 'R', payment_information: '0')
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<issuer_id>xyz987<\/issuer_id>/, data)
+      assert_match(/<payment_indicator>R<\/payment_indicator>/, data)
+      assert_match(/<payment_information>0<\/payment_information>/, data)
+    end.respond_with(successful_first_cof_authorize_response)
+
+    assert_success response
+  end
+
   private
+
+  def stored_credential_options(*args, id: nil)
+    {
+      order_id: '#1001',
+      description: 'AM test',
+      currency: 'CAD',
+      customer: '123',
+      stored_credential: stored_credential(*args, id: id),
+      issuer_id: ''
+    }
+  end
 
   def successful_purchase_response
     <<-RESPONSE
@@ -349,6 +594,92 @@ class MonerisTest < Test::Unit::TestCase
   </receipt>
 </response>
 
+    RESPONSE
+  end
+
+  def successful_first_cof_purchase_response
+    <<-RESPONSE
+<?xml version=\"1.0\" standalone=\"yes\"?>
+<?xml version=“1.0” standalone=“yes”?>
+<response>
+ <receipt>
+   <ReceiptId>a33ba7edd448b91ef8d2f85fea614b8d</ReceiptId>
+   <ReferenceNum>660114080015099160</ReferenceNum>
+   <ResponseCode>027</ResponseCode>
+   <ISO>01</ISO>
+   <AuthCode>822665</AuthCode>
+   <TransTime>07:43:28</TransTime>
+   <TransDate>2018-11-11</TransDate>
+   <TransType>00</TransType>
+   <Complete>true</Complete>
+   <Message>APPROVED           *                    =</Message>
+   <TransAmount>1.00</TransAmount>
+   <CardType>V</CardType>
+   <TransID>799655-0_11</TransID>
+   <TimedOut>false</TimedOut>
+   <BankTotals>null</BankTotals>
+   <Ticket>null</Ticket>
+   <IssuerId>355689484440192</IssuerId>
+   <IsVisaDebit>false</IsVisaDebit>
+ </receipt>
+</response>
+    RESPONSE
+  end
+
+  def successful_first_cof_authorize_response
+    <<-RESPONSE
+<?xml version=\"1.0\" standalone=\"yes\"?>
+<response>
+  <receipt>
+    <ReceiptId>8dbc28468af2007779bbede7ec1bab6c</ReceiptId>
+    <ReferenceNum>660109300018229130</ReferenceNum>
+    <ResponseCode>027</ResponseCode>
+    <ISO>01</ISO>
+    <AuthCode>718280</AuthCode>
+    <TransTime>07:50:53</TransTime>
+    <TransDate>2018-11-11</TransDate>
+    <TransType>01</TransType>
+    <Complete>true</Complete>
+    <Message>APPROVED           *                    =</Message>
+    <TransAmount>1.00</TransAmount>
+    <CardType>V</CardType>
+    <TransID>830724-0_11</TransID>
+    <TimedOut>false</TimedOut>
+    <BankTotals>null</BankTotals>
+    <Ticket>null</Ticket>
+    <MessageId>1A8315282537312</MessageId>
+    <IssuerId>550923784451193</IssuerId>
+    <IsVisaDebit>false</IsVisaDebit>
+  </receipt>
+</response>
+    RESPONSE
+  end
+
+  def successful_subsequent_cof_purchase_response
+    <<-RESPONSE
+<?xml version="1.0" standalone="yes"?>
+<response>
+  <receipt>
+    <ReceiptId>830724-0_11;8dbc28468af2007779bbede7ec1bab6c</ReceiptId>
+    <ReferenceNum>660109490014038930</ReferenceNum>
+    <ResponseCode>027</ResponseCode>
+    <ISO>01</ISO>
+    <AuthCode>111234</AuthCode>
+    <TransTime>07:50:54</TransTime>
+    <TransDate>2018-11-11</TransDate>
+    <TransType>00</TransType>
+    <Complete>true</Complete>
+    <Message>APPROVED           *                    =</Message>
+    <TransAmount>1.00</TransAmount>
+    <CardType>V</CardType>
+    <TransID>455422-0_11</TransID>
+    <TimedOut>false</TimedOut>
+    <BankTotals>null</BankTotals>
+    <Ticket>null</Ticket>
+    <IssuerId>762097792112819</IssuerId>
+    <IsVisaDebit>false</IsVisaDebit>
+  </receipt>
+</response>
     RESPONSE
   end
 
@@ -564,10 +895,66 @@ class MonerisTest < Test::Unit::TestCase
   end
 
   def xml_purchase_fixture
-   '<request><store_id>store1</store_id><api_token>yesguy</api_token><purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></purchase></request>'
+    '<request><store_id>store1</store_id><api_token>yesguy</api_token><purchase><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></purchase></request>'
   end
 
   def xml_capture_fixture
-   '<request><store_id>store1</store_id><api_token>yesguy</api_token><preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></preauth></request>'
+    '<request><store_id>store1</store_id><api_token>yesguy</api_token><preauth><amount>1.01</amount><pan>4242424242424242</pan><expdate>0303</expdate><crypt_type>7</crypt_type><order_id>order1</order_id></preauth></request>'
+  end
+
+  def pre_scrub
+    <<-pre_scrub
+      opening connection to esqa.moneris.com:443...
+      opened
+      starting SSL for esqa.moneris.com:443...
+      SSL established
+      <- "POST /gateway2/servlet/MpgRequest HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: esqa.moneris.com\r\nContent-Length: 176\r\n\r\n"
+      <- "<request><store_id>store1</store_id><api_token>yesguy</api_token><res_add_cc><pan>4242424242424242</pan><expdate>1705</expdate><crypt_type>7</crypt_type></res_add_cc></request>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 16 May 2016 02:35:23 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Type: text/html\r\n"
+      -> "Set-Cookie: TS011902c9=01649737b1334cfbe6b21538231fb4ad142215050461293f17e2dc76d7821e71c2f25055ea; Path=/\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      -> "391\r\n"
+      reading 913 bytes...
+      -> "<?xml version=\"1.0\"?><response><receipt><DataKey>LAmXQeZwdtzUtz1QI1vF6etR2</DataKey><ReceiptId>null</ReceiptId><ReferenceNum>null</ReferenceNum><ResponseCode>001</ResponseCode><ISO>null</ISO><AuthCode>null</AuthCode><Message>Successfully registered CC details.</Message><TransTime>22:35:23</TransTime><TransDate>2016-05-15</TransDate><TransType>null</TransType><Complete>true</Complete><TransAmount>null</TransAmount><CardType>null</CardType><TransID>null</TransID><TimedOut>false</TimedOut><CorporateCard>null</CorporateCard><RecurSuccess>null</RecurSuccess><AvsResultCode>null</AvsResultCode><CvdResultCode>null</CvdResultCode><ResSuccess>true</ResSuccess><PaymentType>cc</PaymentType><IsVisaDebit>null</IsVisaDebit><ResolveData><cust_id></cust_id><phone></phone><email></email><note></note><crypt_type>7</crypt_type><masked_pan>4242***4242</masked_pan><expdate>1705</expdate></ResolveData></receipt></response>"
+      read 913 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    pre_scrub
+  end
+
+  def post_scrub
+    <<-post_scrub
+      opening connection to esqa.moneris.com:443...
+      opened
+      starting SSL for esqa.moneris.com:443...
+      SSL established
+      <- "POST /gateway2/servlet/MpgRequest HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: esqa.moneris.com\r\nContent-Length: 176\r\n\r\n"
+      <- "<request><store_id>[FILTERED]</store_id><api_token>[FILTERED]</api_token><res_add_cc><pan>[FILTERED]</pan><expdate>1705</expdate><crypt_type>7</crypt_type></res_add_cc></request>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 16 May 2016 02:35:23 GMT\r\n"
+      -> "Connection: close\r\n"
+      -> "Content-Type: text/html\r\n"
+      -> "Set-Cookie: TS011902c9=01649737b1334cfbe6b21538231fb4ad142215050461293f17e2dc76d7821e71c2f25055ea; Path=/\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      -> "391\r\n"
+      reading 913 bytes...
+      -> "<?xml version=\"1.0\"?><response><receipt><DataKey>LAmXQeZwdtzUtz1QI1vF6etR2</DataKey><ReceiptId>null</ReceiptId><ReferenceNum>null</ReferenceNum><ResponseCode>001</ResponseCode><ISO>null</ISO><AuthCode>null</AuthCode><Message>Successfully registered CC details.</Message><TransTime>22:35:23</TransTime><TransDate>2016-05-15</TransDate><TransType>null</TransType><Complete>true</Complete><TransAmount>null</TransAmount><CardType>null</CardType><TransID>null</TransID><TimedOut>false</TimedOut><CorporateCard>null</CorporateCard><RecurSuccess>null</RecurSuccess><AvsResultCode>null</AvsResultCode><CvdResultCode>null</CvdResultCode><ResSuccess>true</ResSuccess><PaymentType>cc</PaymentType><IsVisaDebit>null</IsVisaDebit><ResolveData><cust_id></cust_id><phone></phone><email></email><note></note><crypt_type>7</crypt_type><masked_pan>4242***4242</masked_pan><expdate>1705</expdate></ResolveData></receipt></response>"
+      read 913 bytes
+      reading 2 bytes...
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    post_scrub
   end
 end


### PR DESCRIPTION
**Why:**
There is a new mandate that is coming into effect on April 2020. It is called Credential on File . What this mandate requires is that merchants who transact using stored cards need to send additional fields ( cof object) to indicate if the card is being stored and whether it is an initial transaction or subsequent transaction

**What:**
Copied support for Credential on File from upstream ActiveMerchant.