### PR TITLE
Stripe: add support for statement_descriptor_suffix

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -319,6 +319,7 @@ module ActiveMerchant #:nodoc:
           add_customer_data(post, options)
           post[:description] = options[:description]
           post[:statement_descriptor] = options[:statement_description]
+          post[:statement_descriptor_suffix] = options[:statement_descriptor_suffix] if options[:statement_descriptor_suffix]
           post[:receipt_email] = options[:receipt_email] if options[:receipt_email]
           add_customer(post, payment, options)
           add_flags(post, options)


### PR DESCRIPTION
Adds support for the statement_descriptor_suffix attribute when charging a card.

This is present in upstream active_merchant master: 
https://github.com/activemerchant/active_merchant/blob/eb37012ffbb6a374605be21a48e1bab688aa4056/lib/active_merchant/billing/gateways/stripe.rb#L365

It was added in this commit: https://github.com/activemerchant/active_merchant/commit/3b1fdadbb7a3240790086016c719bc8696773a98