### PR TITLE
Statement Descriptor - Braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -421,6 +421,7 @@ module ActiveMerchant #:nodoc:
         params = {}
         params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
         params[:braintree_transaction] = transaction_hash(result)
+        params[:descriptor] = result.transaction.descriptor.as_json if result.transaction
         params
       end
 


### PR DESCRIPTION
### Why:
**Summary for requirement:**

Merchants must add a descriptor that indicates a transaction related to a trial offer to the first transaction processed after the trial offer ends. This descriptor should be added to the Merchant Name field of the Clearing Record and should include language like “trial,” “trial period,” “free trial,” and the like. This will then appear on bank statements, banking apps, and text alerts that the cardholder sees.

**What is the enhanced descriptor for? Where is it required? ([Visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/subscription-policy-vbn-visa-public.pdf))**

The enhanced descriptor (e.g., “trial,” “trial period,” “free trial”) is to be included in the Merchant Name field of the clearing record for the first transaction at the end of a trial period. It is not required for subsequent transactions. This descriptor will then appear on cardholder statements, online banking, mobile apps and SMS / text alerts, in the same way discretionary data or additional invoice / order numbers appear for e-commerce transactions today, to identify the nature of the transaction. Visa is not restricting the word choice of the enhanced descriptor, as long as the merchant can identify that it is a trial-related transaction for the cardholder and issuer.

**Additional info from [visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/visa-new-subscription-rules-flier.pdf)**

Statement Descriptor An additional descriptor indicating a trial period-related transaction will be required in the Merchant Name field of the Clearing Record for the first transaction at the end of a trial period. This descriptor (for example, “trial,” “trial period,” “free trial”) will then appear on cardholder statements, online banking, mobile apps, and SMS/text alerts, in the same way discretionary, additional invoice/order numbers appear for electronic commerce transactions.


### What:
**Required technical changes ([source](https://www.braintreepayments.com/blog/visa-updates-for-merchants-that-offer-trial-subscriptions/))**

- Update the [descriptor name in the transaction.sale call](https://developers.braintreepayments.com/reference/request/transaction/sale/ruby?&_ga=2.33360190.1882691418.1585060234-656716603.1583481603#descriptor.name) to include a trial or promotional reference.

- For subsequent subscription transactions, remove the trial reference from your descriptors.

_Company name/DBA section must be either 3, 7 or 12 characters and the product descriptor can be up to 18, 14, or 9 characters respectively (with an * in between for a total descriptor name of 22 characters)_
### Test:

1. Create a Product with Trial and set:
`product.default_product_price_point.update_column(:introductory_offer, true)`

2. Create Subscription with created Plan.

3. After the first payment after the trial period open the Braintree transactions page and find this transaction.
You should see: 
![image](https://user-images.githubusercontent.com/8780680/78247714-a144d200-74eb-11ea-9b6e-e2601635e29a.png)

Also, You can find params on _raw_gateway_logs_ page 

```
http://app.chargify.test/admin/raw_gateway_logs/
request: 
<descriptor>
  <name>company*trial end</name>
</descriptor>

response:
<descriptor>
  <name>company*trial end</name>
</descriptor>

```
