### PR TITLE
Statement Descriptor - Braintree - fix .as_json bug

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -421,7 +421,6 @@ module ActiveMerchant #:nodoc:
         params = {}
         params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
         params[:braintree_transaction] = transaction_hash(result)
-        params[:descriptor] = JSON.parse(result.transaction.descriptor.to_json) if result.transaction&.descriptor
         params
       end
 
@@ -591,6 +590,12 @@ module ActiveMerchant #:nodoc:
           "token"               => transaction.credit_card_details.token
         }
 
+        descriptor = {
+          "name"  => transaction&.descriptor&.name,
+          "phone" => transaction&.descriptor&.phone,
+          "url"   => transaction&.descriptor&.url
+        }
+
         {
           "order_id"                => transaction.order_id,
           "status"                  => transaction.status,
@@ -600,7 +605,8 @@ module ActiveMerchant #:nodoc:
           "shipping_details"        => shipping_details,
           "vault_customer"          => vault_customer,
           "merchant_account_id"     => transaction.merchant_account_id,
-          "processor_response_code" => response_code_from_result(result)
+          "processor_response_code" => response_code_from_result(result),
+          "descriptor"              => descriptor
         }
       end
 

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -421,7 +421,7 @@ module ActiveMerchant #:nodoc:
         params = {}
         params[:customer_vault_id] = result.transaction.customer_details.id if result.success?
         params[:braintree_transaction] = transaction_hash(result)
-        params[:descriptor] = result.transaction.descriptor.as_json if result.transaction
+        params[:descriptor] = JSON.parse(result.transaction.descriptor.to_json) if result.transaction&.descriptor
         params
       end
 


### PR DESCRIPTION
### Why
ruby does not support `.as_json`

### What
move `descriptor params` to `transaction_hash` method