### PR TITLE
Cybersource Statement Descriptor

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -440,6 +440,15 @@ module ActiveMerchant #:nodoc:
         xml.tag! 'clientLibrary', 'Ruby Active Merchant'
         xml.tag! 'clientLibraryVersion',  VERSION
         xml.tag! 'clientEnvironment', RUBY_PLATFORM
+        add_merchant_descriptor(xml, options)
+      end
+
+      def add_merchant_descriptor(xml, options)
+        return unless options[:merchant_descriptor]
+
+        xml.tag! 'invoiceHeader' do
+          xml.tag! 'merchantDescriptor', options[:merchant_descriptor]
+        end
       end
 
       def add_purchase_data(xml, money = 0, include_grand_total = false, options={})

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -190,6 +190,13 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_successful_purchase_with_merchant_descriptor
+    @options[:merchant_descriptor] = 'Chargify'
+
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+  end
+
   def test_unsuccessful_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_equal 'Invalid account number', response.message

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -97,6 +97,14 @@ class CyberSourceTest < Test::Unit::TestCase
     end.respond_with(successful_authorization_response)
   end
 
+  def test_purchase_includes_merchant_descriptor
+    stub_comms do
+      @gateway.purchase(100, @credit_card, merchant_descriptor: 'Chargify')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/<merchantDescriptor>Chargify<\/merchantDescriptor>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
   def test_successful_check_purchase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
 


### PR DESCRIPTION
### Why:
**Summary for requirement:**

Merchants must add a descriptor that indicates a transaction related to a trial offer to the first transaction processed after the trial offer ends. This descriptor should be added to the Merchant Name field of the Clearing Record and should include language like “trial,” “trial period,” “free trial,” and the like. This will then appear on bank statements, banking apps, and text alerts that the cardholder sees.

**What is the enhanced descriptor for? Where is it required? ([Visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/subscription-policy-vbn-visa-public.pdf))**

The enhanced descriptor (e.g., “trial,” “trial period,” “free trial”) is to be included in the Merchant Name field of the clearing record for the first transaction at the end of a trial period. It is not required for subsequent transactions. This descriptor will then appear on cardholder statements, online banking, mobile apps and SMS / text alerts, in the same way discretionary data or additional invoice / order numbers appear for e-commerce transactions today, to identify the nature of the transaction. Visa is not restricting the word choice of the enhanced descriptor, as long as the merchant can identify that it is a trial-related transaction for the cardholder and issuer.

**Additional info from [visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/visa-new-subscription-rules-flier.pdf)**

Statement Descriptor An additional descriptor indicating a trial period-related transaction will be required in the Merchant Name field of the Clearing Record for the first transaction at the end of a trial period. This descriptor (for example, “trial,” “trial period,” “free trial”) will then appear on cardholder statements, online banking, mobile apps, and SMS/text alerts, in the same way discretionary, additional invoice/order numbers appear for electronic commerce transactions.


### What:
**Required technical changes ([from cybersource documentation](https://developer.cybersource.com/api/soap-developer-guides/dita-payments/intro/optional.html#id192CD0R0FF4_id192CE050QVE))**

> You can provide a merchant descriptor to be displayed on the customer’s bank account statement. The descriptor includes your company’s name and a description of the product or service that was purchased.
> The merchant descriptor field overrides the corresponding value in your CyberSource account. If you do not include this field in the request, CyberSource uses the company name from your merchant account.
> Before sending a merchant descriptor with a payment or credit request, check with your processor to find out if you need to register your merchant descriptor information with them.
> The merchantInformation.merchantDescriptor.name field requires a particular format:
> Characters 1-15: name of your company. If the name is fewer than 15 characters, use spaces to fill in the full 15 characters. If the name is more than 15 characters, provide only the first 15 characters of the name.
> Characters 16-25: description of the product or service.

_Please note - when I used the above instruction, the payment did not process, coming back with an error of incorrectly formatted merchant_descriptor field. I used simple `trial ended` because of that._
### Test:

1. Create a site with Cybersource as the Gateway. 

2. Create a Product with Trial and set:
`product.default_product_price_point.update_column(:introductory_offer, true)`

3. Create Subscription with created the Trial Plan.

3. `Process now!` the subscription to simulate the first payment after the trial period.

4. Open the Cybersource transactions page and find this transaction.
You should see: 
<img width="623" alt="EBC___Transaction_Management___Transaction_Details" src="https://user-images.githubusercontent.com/43703374/78679598-bace8b00-78ea-11ea-82d3-f1b261359efa.png">

Also, You can find params on _raw_gateway_logs_ page 

```
http://app.chargify.test/admin/raw_gateway_logs/

request: 
<merchantDescriptor>trial end</merchantDescriptor>

```
Cybersource does not send the `merchant_descriptor` field in response unfortunately, so we will not see it there.