### PR TITLE
[Visa][Statement Descriptor] - Adyen

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -39,6 +39,7 @@ module ActiveMerchant #:nodoc:
         post = init_post(options)
         add_invoice(post, money, options)
         add_payment(post, payment)
+        add_extra_data(post, options)
         add_stored_credentials(post, payment, options)
         add_shopper_reference(post, options)
         commit('payments', post, options)


### PR DESCRIPTION
### Why:
**Summary for requirement:**

Merchants must add a descriptor that indicates a transaction related to a trial offer to the first transaction processed after the trial offer ends. This descriptor should be added to the Merchant Name field of the Clearing Record and should include language like “trial,” “trial period,” “free trial,” and the like. This will then appear on bank statements, banking apps, and text alerts that the cardholder sees.

**What is the enhanced descriptor for? Where is it required? ([Visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/subscription-policy-vbn-visa-public.pdf))**

The enhanced descriptor (e.g., “trial,” “trial period,” “free trial”) is to be included in the Merchant Name field of the clearing record for the first transaction at the end of a trial period. It is not required for subsequent transactions. This descriptor will then appear on cardholder statements, online banking, mobile apps and SMS / text alerts, in the same way discretionary data or additional invoice / order numbers appear for e-commerce transactions today, to identify the nature of the transaction. Visa is not restricting the word choice of the enhanced descriptor, as long as the merchant can identify that it is a trial-related transaction for the cardholder and issuer.

**Additional info from [visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/visa-new-subscription-rules-flier.pdf)**

Statement Descriptor An additional descriptor indicating a trial period-related transaction will be required in the Merchant Name field of the Clearing Record for the first transaction at the end of a trial period. This descriptor (for example, “trial,” “trial period,” “free trial”) will then appear on cardholder statements, online banking, mobile apps, and SMS/text alerts, in the same way discretionary, additional invoice/order numbers appear for electronic commerce transactions.


### What:

_For Adyen acquiring, you can submit the dynamic description in a payment request by submitting the [shopperStatement](https://docs.adyen.com/api-explorer/#/PaymentSetupAndVerificationService/v49/payments__reqParam_shopperStatement) field. This value is then appended to the merchant name in Visa/Mastercard authorization and capture messages._  ([source](https://support.adyen.com/hc/en-us/articles/115001182924-Is-it-possible-to-show-the-merchant-name-on-the-shopper-s-statement-))

### Test:

1. Create a Product with Trial and set:
`product.default_product_price_point.update_column(:introductory_offer, true)`

2. Create Subscription with created Plan.

3. After the first payment after the trial period open the Braintree transactions page and find this transaction.
You should see: 
<img width="993" alt="Screenshot 2020-04-10 at 14 30 04" src="https://user-images.githubusercontent.com/8780680/78990917-f0b47f00-7b37-11ea-9ab6-fba44cfa4cb9.png">

