### PR TITLE
Refactor and fix Rubocop warnings

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -149,7 +149,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_billing_address(post, options)
-        return unless address == options[:billing_address] || options[:address]
+        return unless (address = options[:billing_address] || options[:address])
 
         post[:addresses] = []
         billing_address = {}
@@ -166,7 +166,7 @@ module ActiveMerchant #:nodoc:
 
       def add_billing_address(post, payment, options)
         post[:billing_address] = {}
-        if address == options[:billing_address] || options[:address]
+        if (address = options[:billing_address] || options[:address])
           first_name, last_name = split_names(address[:name])
           post[:billing_address][:first_name] = first_name if first_name
           post[:billing_address][:last_name] = last_name if last_name

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -5,37 +5,38 @@ module ActiveMerchant #:nodoc:
     class ForteGateway < Gateway
       include Empty
 
-      self.test_url = 'https://sandbox.forte.net/api/v2'
-      self.live_url = 'https://api.forte.net/v2'
+      self.test_url = 'https://sandbox.forte.net/api/v2/'
+      self.live_url = 'https://api.forte.net/v2/'
 
       self.supported_countries = ['US']
       self.default_currency = 'USD'
-      self.supported_cardtypes = [:visa, :master, :american_express, :discover]
+      self.supported_cardtypes = %i[visa master american_express discover]
 
       self.homepage_url = 'https://www.forte.net'
       self.display_name = 'Forte'
 
-      def initialize(options={})
+      def initialize(options = {})
         requires!(options, :api_key, :secret, :location_id)
-        unless options.has_key?(:organization_id) || options.has_key?(:account_id)
-          raise ArgumentError.new("Missing required parameter: organization_id or account_id")
+        unless options.key?(:organization_id) || options.key?(:account_id)
+          raise ArgumentError.new('Missing required parameter: organization_id or account_id')
         end
+
         super
       end
 
-      def purchase(money, payment_method, options={})
+      def purchase(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
         add_payment_method(post, payment_method)
-        add_billing_address(post, payment_method, options) unless payment_method.kind_of?(String)
-        add_shipping_address(post, options) unless payment_method.kind_of?(String)
+        add_billing_address(post, payment_method, options) unless payment_method.is_a?(String)
+        add_shipping_address(post, options) unless payment_method.is_a?(String)
         post[:action] = 'sale'
 
-        commit(:post, "/transactions", post)
+        commit(:post, 'transactions', post)
       end
 
-      def authorize(money, payment_method, options={})
+      def authorize(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -44,19 +45,19 @@ module ActiveMerchant #:nodoc:
         add_shipping_address(post, options)
         post[:action] = 'authorize'
 
-        commit(:post, "/transactions", post)
+        commit(:post, 'transactions', post)
       end
 
-      def capture(money, authorization, options={})
+      def capture(_money, authorization, _options = {})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization) || ''
         post[:action] = 'capture'
 
-        commit(:put, "/transactions", post)
+        commit(:put, 'transactions', post)
       end
 
-      def credit(money, payment_method, options={})
+      def credit(money, payment_method, options = {})
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
@@ -64,17 +65,17 @@ module ActiveMerchant #:nodoc:
         add_billing_address(post, payment_method, options)
         post[:action] = 'disburse'
 
-        commit(:post, "/transactions", post)
+        commit(:post, 'transactions', post)
       end
 
-      def refund(money, authorization, options={})
+      def refund(money, authorization, options = {})
         post = {}
         add_amount(post, money, options)
         post[:original_transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization)
         post[:action] = 'reverse'
 
-        commit(:post, "/transactions", post)
+        commit(:post, 'transactions', post)
       end
 
       def store(credit_card, options = {})
@@ -83,27 +84,27 @@ module ActiveMerchant #:nodoc:
         add_customer_paymethod(post, credit_card)
         add_customer_billing_address(post, options)
 
-        commit(:post, "/customers", post)
+        commit(:post, 'customers', post)
       end
 
-      def unstore(identification, options = {})
-        customer_token, paymethod_token = identification.split('|')
+      def unstore(identification, _options = {})
+        customer_token, _paymethod_token = identification.split('|')
 
         # TODO: support deleting just a card and not the whole customer
 
-        commit(:delete, "/customers/#{customer_token}", {})
+        commit(:delete, "customers/#{customer_token}", {})
       end
 
-      def void(authorization, options={})
+      def void(authorization, _options = {})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)
         post[:authorization_code] = authorization_code_from(authorization)
         post[:action] = 'void'
 
-        commit(:put, "/transactions", post)
+        commit(:put, 'transactions', post)
       end
 
-      def verify(credit_card, options={})
+      def verify(credit_card, options = {})
         MultiResponse.run(:use_first_response) do |r|
           r.process { authorize(100, credit_card, options) }
           r.process(:ignore_result) { void(r.authorization, options) }
@@ -115,28 +116,23 @@ module ActiveMerchant #:nodoc:
       end
 
       def scrub(transcript)
-        transcript.
-          gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
-          gsub(%r((account_number)\W+\d+), '\1[FILTERED]').
-          gsub(%r((card_verification_value)\W+\d+), '\1[FILTERED]')
+        transcript
+          .gsub(/(Authorization: Basic )\w+/, '\1[FILTERED]')
+          .gsub(/(account_number)\W+\d+/, '\1[FILTERED]')
+          .gsub(/(card_verification_value)\W+\d+/, '\1[FILTERED]')
       end
 
       private
-
-      def add_auth(post)
-        post[:account_id] = "act_#{organization_id}"
-        post[:location_id] = "loc_#{@options[:location_id]}"
-      end
 
       def add_invoice(post, options)
         post[:order_number] = options[:order_id]
       end
 
-      def add_amount(post, money, options)
+      def add_amount(post, money, _options)
         post[:authorization_amount] = amount(money)
       end
 
-      def add_customer(post, payment_method, options)
+      def add_customer(post, payment_method, _options)
         post[:first_name] = payment_method.first_name
         post[:last_name] = payment_method.last_name
       end
@@ -153,24 +149,24 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_customer_billing_address(post, options)
+        return unless address == options[:billing_address] || options[:address]
+
         post[:addresses] = []
-        if address = options[:billing_address] || options[:address]
-          billing_address = {}
-          billing_address[:address_type] = "default_billing"
-          billing_address[:physical_address] = {}
-          billing_address[:physical_address][:street_line1] = address[:address1] if address[:address1]
-          billing_address[:physical_address][:street_line2] = address[:address2] if address[:address2]
-          billing_address[:physical_address][:postal_code] = address[:zip] if address[:zip]
-          billing_address[:physical_address][:region] = address[:state] if address[:state]
-          billing_address[:physical_address][:locality] = address[:city] if address[:city]
-          billing_address[:email] = options[:email] if options[:email]
-          post[:addresses] << billing_address
-        end
+        billing_address = {}
+        billing_address[:address_type] = "default_billing"
+        billing_address[:physical_address] = {}
+        billing_address[:physical_address][:street_line1] = address[:address1] if address[:address1]
+        billing_address[:physical_address][:street_line2] = address[:address2] if address[:address2]
+        billing_address[:physical_address][:postal_code] = address[:zip] if address[:zip]
+        billing_address[:physical_address][:region] = address[:state] if address[:state]
+        billing_address[:physical_address][:locality] = address[:city] if address[:city]
+        billing_address[:email] = options[:email] if options[:email]
+        post[:addresses] << billing_address
       end
 
       def add_billing_address(post, payment, options)
         post[:billing_address] = {}
-        if address = options[:billing_address] || options[:address]
+        if address == options[:billing_address] || options[:address]
           first_name, last_name = split_names(address[:name])
           post[:billing_address][:first_name] = first_name if first_name
           post[:billing_address][:last_name] = last_name if last_name
@@ -204,7 +200,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_payment_method(post, payment_method)
-        if payment_method.kind_of?(String)
+        if payment_method.is_a?(String)
           if payment_method.include?('|')
             customer_token, paymethod_token = payment_method.split('|')
             add_customer_token(post, customer_token)
@@ -229,7 +225,7 @@ module ActiveMerchant #:nodoc:
         # TODO: make sec_code configurable in options hash
         # sec_code is temporarily hard-coded as "WEB" to fix remote test failure
         # see public issue https://github.com/activemerchant/active_merchant/issues/3612
-        post[:echeck][:sec_code] = "WEB"
+        post[:echeck][:sec_code] = 'WEB'
       end
 
       def add_credit_card(post, payment)
@@ -250,41 +246,31 @@ module ActiveMerchant #:nodoc:
         post[:paymethod_token] = payment_method
       end
 
-      def commit(type, path, parameters)
-        add_auth(parameters)
+      def commit(http_method, path, params)
+        body = http_method == :delete ? nil : params.to_json
+        url = URI.join(base_url, path)
 
-        url = (test? ? test_url : live_url) + endpoint + path
-        body = type == :delete ? nil : parameters.to_json
-        response = parse(handle_resp(raw_ssl_request(type, url, body, headers)))
+        send_request(http_method, url, body, headers)
+      end
+
+      def send_request(http_method, url, body, headers)
+        response = JSON.parse(ssl_request(http_method, url, body, headers))
 
         Response.new(
           success_from(response),
           message_from(response),
           response,
-          authorization: authorization_from(response, parameters),
+          authorization: authorization_from(response, body),
           avs_result: AVSResult.new(code: response['response']['avs_result']),
           cvv_result: CVVResult.new(response['response']['cvv_code']),
           test: test?
         )
       end
 
-      def handle_resp(response)
-        case response.code.to_i
-        when 200..499
-          response.body
-        else
-          raise ResponseError.new(response)
-        end
-      end
-
-      def parse(response_body)
-        JSON.parse(response_body)
-      end
-
       def success_from(response)
         response['response']['response_code'] == 'A01' ||
-          response['response']['response_desc'] == "Create Successful." ||
-          response['response']['response_desc'] == "Delete Successful."
+          response['response']['response_desc'] == 'Create Successful.' ||
+          response['response']['response_desc'] == 'Delete Successful.'
       end
 
       def message_from(response)
@@ -299,8 +285,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def endpoint
-          "/accounts/act_#{organization_id.strip}/locations/loc_#{@options[:location_id].strip}"
+      def base_url
+        URI.join(
+          (test? ? test_url : live_url),
+          'accounts/',
+          "act_#{organization_id.strip}/",
+          'locations/',
+          "loc_#{@options[:location_id].strip}/"
+        )
       end
 
       def headers
@@ -314,13 +306,13 @@ module ActiveMerchant #:nodoc:
       def format_card_brand(card_brand)
         case card_brand
         when 'visa'
-          return 'visa'
+          'visa'
         when 'master'
-          return 'mast'
+          'mast'
         when 'american_express'
-          return 'amex'
+          'amex'
         when 'discover'
-          return 'disc'
+          'disc'
         end
       end
 


### PR DESCRIPTION
This PR:

- Uses `URI.join` to safely form URLs
- Gets rid of `add_auth` since we're using a base URL that contains org + location info
- ~~Replaces `raw_ssl_request` with `ssl_request` which allows us to get rid of overriding `handle_resp`~~ (didn't work)
- ~~Splits the HTTP-specific part of `commit` into a separate method~~ (didn't work either)
- Fixes most Rubocop warnings