### PR TITLE
Implement unstore for card only

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -89,9 +89,11 @@ module ActiveMerchant #:nodoc:
       def unstore(identification, options = {})
         customer_token, paymethod_token = identification.split('|')
 
-        # TODO: support deleting just a card and not the whole customer
-
-        commit(:delete, "/customers/#{customer_token}", {})
+        if (customer_token && !paymethod_token)
+          commit(:delete, "/customers/#{customer_token}", {})
+        else
+          commit(:delete, "/paymethods/#{paymethod_token}", {})
+        end
       end
 
       def void(authorization, options={})

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -88,12 +88,12 @@ module ActiveMerchant #:nodoc:
       end
 
       def unstore(identification, _options = {})
-        customer_token, _paymethod_token = identification.split('|')
+        customer_token, paymethod_token = identification.split('|')
 
         if (customer_token && !paymethod_token)
-          commit(:delete, "/customers/#{customer_token}", {})
+          commit(:delete, "customers/#{customer_token}", {})
         else
-          commit(:delete, "/paymethods/#{paymethod_token}", {})
+          commit(:delete, "paymethods/#{paymethod_token}", {})
         end
       end
 

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -90,7 +90,7 @@ module ActiveMerchant #:nodoc:
       def unstore(identification, _options = {})
         customer_token, paymethod_token = identification.split('|')
 
-        if (customer_token && !paymethod_token)
+        if customer_token && !paymethod_token
           commit(:delete, "customers/#{customer_token}", {})
         else
           commit(:delete, "paymethods/#{paymethod_token}", {})

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -219,12 +219,23 @@ class RemoteForteTest < Test::Unit::TestCase
     assert purchase_response.params['transaction_id'].start_with?("trn_")
   end
 
-  def test_successful_store_and_unstore
+  def test_successful_store_and_unstore_of_customer
     assert store_response = @gateway.store(@credit_card, :billing_address => address)
     assert_success store_response
     assert_equal 'Create Successful.', store_response.message
 
     vault_id = store_response.params['customer_token']
+    assert unstore_response = @gateway.unstore(vault_id)
+    assert_success unstore_response
+    assert_equal 'Delete Successful.', unstore_response.message
+  end
+
+  def test_successful_store_of_customer_and_unstore_of_only_paymethod
+    assert store_response = @gateway.store(@credit_card, :billing_address => address)
+    assert_success store_response
+    assert_equal 'Create Successful.', store_response.message
+
+    vault_id = store_response.params['customer_token'] + "|" + store_response.params['default_paymethod_token']
     assert unstore_response = @gateway.unstore(vault_id)
     assert_success unstore_response
     assert_equal 'Delete Successful.', unstore_response.message

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -228,6 +228,8 @@ class RemoteForteTest < Test::Unit::TestCase
     assert unstore_response = @gateway.unstore(vault_id)
     assert_success unstore_response
     assert_equal 'Delete Successful.', unstore_response.message
+    assert unstore_response.params['customer_token'].present?
+    assert unstore_response.params['paymethod_token'].blank?
   end
 
   def test_successful_store_of_customer_and_unstore_of_only_paymethod
@@ -240,6 +242,8 @@ class RemoteForteTest < Test::Unit::TestCase
     assert unstore_response = @gateway.unstore(vault_id)
     assert_success unstore_response
     assert_equal 'Delete Successful.', unstore_response.message
+    assert unstore_response.params['customer_token'].blank?
+    assert unstore_response.params['paymethod_token'].present?
   end
 
   def test_transcript_scrubbing

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -236,6 +236,7 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal 'Create Successful.', store_response.message
 
     vault_id = store_response.params['customer_token'] + "|" + store_response.params['default_paymethod_token']
+
     assert unstore_response = @gateway.unstore(vault_id)
     assert_success unstore_response
     assert_equal 'Delete Successful.', unstore_response.message


### PR DESCRIPTION
Previously, the unstore method only deleted the entire customer.

Since Forte allows multiple cards per customer, this commit allows users to specify either a customer id, which deletes the entire customer, or both a customer and card id, in which case only the card will be deleted.

