### PR TITLE
Forte: add sec_code attribute for echeck

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -28,7 +28,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
-        add_payment_method(post, payment_method)
+        add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options) unless payment_method.is_a?(String)
         add_shipping_address(post, options) unless payment_method.is_a?(String)
         post[:action] = "sale"
@@ -40,7 +40,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
-        add_payment_method(post, payment_method)
+        add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
         add_shipping_address(post, options)
         post[:action] = "authorize"
@@ -61,7 +61,7 @@ module ActiveMerchant #:nodoc:
         post = {}
         add_amount(post, money, options)
         add_invoice(post, options)
-        add_payment_method(post, payment_method)
+        add_payment_method(post, payment_method, options)
         add_billing_address(post, payment_method, options)
         post[:action] = "disburse"
 
@@ -228,7 +228,7 @@ module ActiveMerchant #:nodoc:
         post[:shipping_address][:physical_address][:locality] = address[:city] if address[:city]
       end
 
-      def add_payment_method(post, payment_method)
+      def add_payment_method(post, payment_method, options)
         if payment_method.is_a?(String)
           if payment_method.include?("|")
             customer_token, paymethod_token = payment_method.split("|")
@@ -240,21 +240,18 @@ module ActiveMerchant #:nodoc:
         elsif payment_method.respond_to?(:brand)
           add_credit_card(post, payment_method)
         else
-          add_echeck(post, payment_method)
+          add_echeck(post, payment_method, options)
         end
       end
 
-      def add_echeck(post, payment)
+      def add_echeck(post, payment, options)
         post[:echeck] = {}
         post[:echeck][:account_holder] = payment.name
         post[:echeck][:account_number] = payment.account_number
         post[:echeck][:routing_number] = payment.routing_number
         post[:echeck][:account_type] = payment.account_type
         post[:echeck][:check_number] = payment.number
-        # TODO: make sec_code configurable in options hash
-        # sec_code is temporarily hard-coded as "WEB" to fix remote test failure
-        # see public issue https://github.com/activemerchant/active_merchant/issues/3612
-        post[:echeck][:sec_code] = "WEB"
+        post[:echeck][:sec_code] = options[:sec_code] || "WEB"
       end
 
       def add_credit_card(params, payment_method)

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -43,6 +43,18 @@ class RemoteForteTest < Test::Unit::TestCase
     response = @gateway.purchase(@amount, @check, @options)
     assert_success response
     assert_equal 'APPROVED', response.message
+    assert_equal 'WEB', response.params['echeck']['sec_code']
+  end
+
+  def test_successful_purchase_with_echeck_with_more_options
+    options = {
+      sec_code: "PPD"
+    }
+
+    response = @gateway.purchase(@amount, @check, options)
+    assert_success response
+    assert_equal 'APPROVED', response.message
+    assert_equal 'PPD', response.params['echeck']['sec_code']
   end
 
   def test_failed_purchase_with_echeck


### PR DESCRIPTION
Allows passing in the sec_code attribute and defaults to WEB if one is not provided

See https://www.forte.net/devdocs/api_resources/forte_api_v2.htm#echeck

The attribute has been made required in the sandbox in advance of requiring it in production later this year.

Taken from public PR activemerchant/active_merchant 3640