### PR TITLE
Forte: fix unit test failures

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -284,7 +284,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(http_method, path, params)
-        url = URI.join(base_url, path).to_s
+        url = URI.join(base_url, path)
         body = http_method == :delete ? nil : params.to_json
         response = JSON.parse(handle_response(raw_ssl_request(http_method, url, body, headers)))
 

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -284,7 +284,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def commit(http_method, path, params)
-        url = URI.join(base_url, path)
+        url = URI.join(base_url, path).to_s
         body = http_method == :delete ? nil : params.to_json
         response = JSON.parse(handle_response(raw_ssl_request(http_method, url, body, headers)))
 

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -165,7 +165,7 @@ class ForteTest < Test::Unit::TestCase
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_type, url, _parameters, _headers|
-      URI.parse(url)
+      url.is_a?(URI) || URI.parse(url)
     end.respond_with(MockedResponse.new(successful_purchase_response))
     assert_success response
   end

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -161,7 +161,7 @@ class ForteTest < Test::Unit::TestCase
   end
 
   def test_handles_improper_padding
-    @gateway = ForteGateway.new(location_id: ' improperly-padded ', account_id: '  account_id  ', api_key: 'api_key', secret: 'secret')
+    @gateway = ForteGateway.new(location_id: ' improperly-padded ', organization_id: '  organization_id  ', api_key: 'api_key', secret: 'secret')
     response = stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, @options)
     end.check_request do |_type, url, _parameters, _headers|

--- a/test/unit/gateways/forte_test.rb
+++ b/test/unit/gateways/forte_test.rb
@@ -28,7 +28,7 @@ class ForteTest < Test::Unit::TestCase
 
   def test_purchase_passes_options
     options = { order_id: '1' }
-    @gateway.expects(:commit).with(anything, has_entries(order_number: '1'))
+    @gateway.expects(:commit).with(anything, anything, has_entries(order_number: '1'))
 
     stub_comms(@gateway, :raw_ssl_request) do
       @gateway.purchase(@amount, @credit_card, options)


### PR DESCRIPTION
- update test with new commit method signature
- check that url is not already a URI before parsing