### PR TITLE
Forte: only default sec_code when bank account details are present

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -252,15 +252,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method(post, payment_method, options)
         if payment_method.is_a?(String)
-          if payment_method.include?('|')
-            customer_token, paymethod_token = payment_method.split('|')
-            add_customer_token(post, customer_token)
-            add_paymethod_token(post, paymethod_token)
-            add_echeck_sec_code(post, options)
-          else
-            add_customer_token(post, payment_method)
-            add_echeck_sec_code(post, options)
-          end
+          add_payment_method_tokens(post, payment_method, options)
         elsif payment_method.respond_to?(:brand)
           add_credit_card(post, payment_method)
         else
@@ -304,6 +296,18 @@ module ActiveMerchant #:nodoc:
 
       def add_action(params, action_name)
         params[:action] = action_name
+      end
+
+      def add_payment_method_tokens(post, payment_method, options)
+        if payment_method.include?('|')
+          customer_token, paymethod_token = payment_method.split('|')
+          add_customer_token(post, customer_token)
+          add_paymethod_token(post, paymethod_token)
+          add_echeck_sec_code(post, options)
+        else
+          add_customer_token(post, payment_method)
+          add_echeck_sec_code(post, options)
+        end
       end
 
       def add_customer_token(post, payment_method)

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -259,6 +259,7 @@ module ActiveMerchant #:nodoc:
             add_echeck_sec_code(post, options)
           else
             add_customer_token(post, payment_method)
+            add_echeck_sec_code(post, options)
           end
         elsif payment_method.respond_to?(:brand)
           add_credit_card(post, payment_method)
@@ -273,12 +274,14 @@ module ActiveMerchant #:nodoc:
         post[:echeck][:account_number] = payment.account_number
         post[:echeck][:routing_number] = payment.routing_number
         post[:echeck][:account_type] = payment.account_type
-        add_echeck_sec_code(post, options)
+        post[:echeck][:sec_code] = options[:sec_code] || 'WEB'
       end
 
       def add_echeck_sec_code(post, options)
-        post[:echeck] ||= {}
-        post[:echeck][:sec_code] = options[:sec_code] || 'WEB'
+        if options[:sec_code]
+          post[:echeck] ||= {}
+          post[:echeck][:sec_code] = options[:sec_code]
+        end
       end
 
       def add_credit_card(params, payment_method)

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -257,7 +257,9 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal 'Create Successful.', response.message
 
     vault_id = response.params['customer_token']
-    purchase_response = @gateway.purchase(@amount, vault_id)
+    options = { sec_code: "WEB" }
+    purchase_response = @gateway.purchase(@amount, vault_id, options)
+    assert_success purchase_response
     assert purchase_response.params['transaction_id'].start_with?("trn_")
   end
 
@@ -267,7 +269,8 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal 'Create Successful.', response.message
 
     vault_id = response.params['customer_token'] + "|" + response.params['default_paymethod_token']
-    purchase_response = @gateway.purchase(@amount, vault_id)
+    options = { sec_code: "WEB" }
+    purchase_response = @gateway.purchase(@amount, vault_id, options)
     assert_success purchase_response
     assert purchase_response.params['transaction_id'].start_with?("trn_")
   end


### PR DESCRIPTION
If customer and/or paymethod tokens are being used, then require sec_code to be set in the options.

We cannot tell whether the paymethod token is for a credit card or a bank account, so we cannot provide a default in this case.

Also extracts logic to split the token on the pipe symbol into a separate method.