### PR TITLE
Forte: ability to update payment method without account number

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -135,6 +135,8 @@ module ActiveMerchant #:nodoc:
           else
             # TODO: add a new address and attach it to the paymethod
           end
+
+          r.process { get_customer(customer_token) }
         end
       end
 
@@ -234,6 +236,12 @@ module ActiveMerchant #:nodoc:
 
       def get_paymethod(paymethod_token)
         path = ['paymethods', paymethod_token].join('/')
+
+        commit(:get, path)
+      end
+
+      def get_customer(customer_token)
+        path = ['customers', customer_token].join('/')
 
         commit(:get, path)
       end

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -348,10 +348,10 @@ module ActiveMerchant #:nodoc:
 
       def add_echeck(post, payment, options)
         post[:echeck] = {}
-        post[:echeck][:account_holder] = payment.name
-        post[:echeck][:account_number] = payment.account_number
-        post[:echeck][:routing_number] = payment.routing_number
-        post[:echeck][:account_type] = payment.account_type
+        post[:echeck][:account_holder] = payment.name if payment.name
+        post[:echeck][:account_number] = payment.account_number if payment.account_number
+        post[:echeck][:routing_number] = payment.routing_number if payment.routing_number
+        post[:echeck][:account_type] = payment.account_type if payment.account_type
         post[:echeck][:sec_code] = options[:sec_code] || 'WEB'
       end
 

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -122,20 +122,19 @@ module ActiveMerchant #:nodoc:
             update_clientless_paymethod(paymethod_token, params)
           end
 
-          r.process { get_paymethod_response = get_paymethod(payment_method) }
-
+          r.process { get_paymethod_response = get_paymethod(paymethod_token) }
           billing_address_token = get_paymethod_response.params['billing_address_token']
 
-          address_options = {}
-          add_email(address_options, options)
-
-          if options[:billing_address].present? && billing_address_token.present?
-            add_physical_address(address_options, options)
+          if billing_address_token.present?
+            address_options = {}
+            add_email(address_options, options)
+            if options[:billing_address].present?
+              add_physical_address(address_options, options)
+            end
+            r.process { update_address(billing_address_token, address_options) } if address_options.keys.present?
           else
             # TODO: add a new address and attach it to the paymethod
           end
-
-          r.process { update_address(billing_address_token, address_options) } if address_options.keys.present?
         end
       end
 
@@ -254,7 +253,7 @@ module ActiveMerchant #:nodoc:
           options[:echeck].delete(:account_number)
         end
 
-        commit(:put, path, params)
+        commit(:put, path, options)
       end
 
       def update_customer(customer_token, options)

--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -98,6 +98,16 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def update(payment_method, options = {})
+        customer_token = options.delete(:customer_token)
+        paymethod_token = options.delete(:paymethod_token)
+
+        post = {}
+        add_customer(post, payment_method, options)
+
+        commit(:put, "customers/#{customer_token}", post)
+      end
+
       def void(authorization, _options = {})
         post = {}
         post[:transaction_id] = transaction_id_from(authorization)
@@ -215,7 +225,7 @@ module ActiveMerchant #:nodoc:
         post[:authorization_amount] = amount(money)
       end
 
-      def add_customer(post, payment_method, _options)
+      def add_customer(post, payment_method, options)
         post[:first_name] = options.dig(:customer, :first_name) || payment_method.first_name
         post[:last_name] = options.dig(:customer, :last_name) || payment_method.last_name
       end

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -412,6 +412,19 @@ class RemoteForteTest < Test::Unit::TestCase
     assert_equal "Error[1]: Payment Method's credit card number is invalid. Error[2]: Payment Method's credit card type is invalid for the credit card number given.", final_response.message
   end
 
+  def test_successful_update
+    store_response = @gateway.store(@credit_card)
+    credit_card = credit_card(nil, { first_name: "Jane", last_name: "Smith"})
+
+    options = {
+      customer_token: store_response.params['customer_token'],
+      paymethod_token: store_response.params['paymethod_token']
+    }
+
+    response = @gateway.update(credit_card, options)
+    assert_success response
+  end
+
   def test_transcript_scrubbing
     @credit_card.verification_value = 789
     transcript = capture_transcript(@gateway) do

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -423,6 +423,22 @@ class RemoteForteTest < Test::Unit::TestCase
 
     response = @gateway.update(credit_card, options)
     assert_success response
+    assert response.params['customer_token'].present?
+    assert response.params['default_paymethod_token'].present?
+  end
+
+  def test_successful_bank_account_update
+    store_response = @gateway.store(@check)
+    options = {
+      customer_token: store_response.params['customer_token'],
+      paymethod_token: store_response.params['paymethod']['paymethod_token']
+    }
+    check = ActiveMerchant::Billing::Check.new(first_name: 'Jane', last_name: 'Smith')
+
+    response = @gateway.update(check, options)
+    assert_success response
+    assert response.params['customer_token'].present?
+    assert response.params['default_paymethod_token'].present?
   end
 
   def test_transcript_scrubbing

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -413,12 +413,12 @@ class RemoteForteTest < Test::Unit::TestCase
   end
 
   def test_successful_update
-    store_response = @gateway.store(@credit_card)
-    credit_card = credit_card(nil, { first_name: "Jane", last_name: "Smith"})
+    store_response = @gateway.store(@credit_card, @options)
+    credit_card = credit_card(nil, { first_name: 'Jane', last_name: 'Smith' })
 
     options = {
       customer_token: store_response.params['customer_token'],
-      paymethod_token: store_response.params['paymethod_token']
+      paymethod_token: store_response.params['paymethod']['paymethod_token']
     }
 
     response = @gateway.update(credit_card, options)


### PR DESCRIPTION
This allows "partial updates" of payment methods (and customers) without supplying the full card number or bank account number.  For example, the name, billing address and expiration date can be updated.

Co-authored-by: Marcelo De Polli <marcelo.polli@gmail.com>