### PR TITLE
[bugfix] Use strict_encode64 with Stripe auth header

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -515,7 +515,7 @@ module ActiveMerchant #:nodoc:
         idempotency_key = options[:idempotency_key]
 
         headers = {
-          "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
+          "Authorization" => "Basic " + Base64.strict_encode64(key.to_s + ":").strip,
           "User-Agent" => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           "Stripe-Version" => api_version(options),
           "X-Stripe-Client-User-Agent" => user_agent,


### PR DESCRIPTION
Fixes: https://chargify.atlassian.net/browse/PGT-396

The regular version of that method, `Base64.encode64`, adds linefeed characters every 60 characters to comply with old clients that have trouble reading big strings.

For some reason, which we haven't still been able to identify, this started being a problem with `Net::HTTP`, which is now responding with:

```
ArgumentError: header field value cannot include CR/LF
from /Users/mdepolli/.asdf/installs/ruby/2.5.5/lib/ruby/2.5.0/net/http/header.rb:23:in `block in initialize_http_header'
```

This fix uses `Base64.strict_encode64`, which is compliant with a different RFC and doesn't add said linefeed characters.

More info: https://ruby-doc.org/stdlib-2.5.5/libdoc/base64/rdoc/Base64.html#method-i-strict_encode64