### PR TITLE
AuthorizeNet: Return error if response cannot be parsed

### DIFF
--- a/lib/active_merchant/billing/gateways/authorize_net_cim.rb
+++ b/lib/active_merchant/billing/gateways/authorize_net_cim.rb
@@ -858,6 +858,8 @@ module ActiveMerchant #:nodoc:
 
         response_params = parse(action, xml)
 
+        return Response.new(false, "Unable to parse response.", {}, {}) if response_params.blank?
+
         message_element= response_params["messages"]["message"]
         first_error = message_element.is_a?(Array) ? message_element.first : message_element
         message = first_error['text']

--- a/test/unit/gateways/authorize_net_cim_test.rb
+++ b/test/unit/gateways/authorize_net_cim_test.rb
@@ -636,6 +636,22 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
     assert_equal 'E00027', response.error_code
   end
 
+  def test_html_error_response
+    @gateway.expects(:ssl_post).returns(html_error_page)
+    assert response = @gateway.create_customer_profile_transaction(
+      :transaction => {
+        :type => :refund,
+        :amount => 1,
+
+        :customer_profile_id => @customer_profile_id,
+        :customer_payment_profile_id => @customer_payment_profile_id,
+        :trans_id => 1
+      }
+    )
+    assert_equal 'Unable to parse response.', response.message
+    assert_nil response.error_code
+  end
+
   private
 
   def get_auth_only_response
@@ -1095,5 +1111,18 @@ class AuthorizeNetCimTest < Test::Unit::TestCase
         <directResponse>#{UNSUCCESSUL_DIRECT_RESPONSE[transaction_type]}</directResponse>
       </createCustomerProfileTransactionResponse>
     XML
+  end
+
+  def html_error_page
+    <<-HTML
+      <html>
+        <head>
+          <title>Error</title>
+        </head>
+        <body>
+          <H2>Error</H2>
+        </body>
+      </html>
+    HTML
   end
 end


### PR DESCRIPTION
AuthorizeNet sometimes responds with an HTML error page, which cannot be parsed as XML.

If the parsed response is blank, (it will be nil,) then return early with an error.

Continuing and trying to access elements in the non-existent hash currently causes errors.