### PR TITLE
[internal] Add retrieve cybersource subscription with token only

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -177,6 +177,10 @@ module ActiveMerchant #:nodoc:
         commit(build_retrieve_subscription_request(reference, options), :retrieve, nil, options)
       end
 
+      def retrieve_with_token(token)
+        commit(build_retrieve_subscription_request_with_token_only(token), :retrieve, nil, options = {})
+      end
+
       # CyberSource requires that you provide line item information for tax
       # calculations. If you do not have prices for each item or want to
       # simplify the situation then pass in one fake line item that costs the
@@ -393,6 +397,16 @@ module ActiveMerchant #:nodoc:
       def build_retrieve_subscription_request(reference, options)
         xml = Builder::XmlMarkup.new :indent => 2
         add_subscription(xml, options, reference)
+        add_subscription_retrieve_service(xml, options)
+        xml.target!
+      end
+
+      def build_retrieve_subscription_request_with_token_only(token, options = {})
+        xml = Builder::XmlMarkup.new :indent => 2
+        xml.tag! 'recurringSubscriptionInfo' do
+          xml.tag! 'subscriptionID', token
+          xml.tag! 'approvalRequired', "false"
+        end
         add_subscription_retrieve_service(xml, options)
         xml.target!
       end

--- a/test/remote/gateways/remote_cyber_source_test.rb
+++ b/test/remote/gateways/remote_cyber_source_test.rb
@@ -390,6 +390,16 @@ class RemoteCyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_retrieve_subscription_with_token
+    assert response = @gateway.store(@credit_card, @subscription_options)
+    assert response.success?
+    assert response.test?
+
+    assert response = @gateway.retrieve_with_token(response.params["requestID"])
+    assert response.success?
+    assert response.test?
+  end
+
   def test_3ds_enroll_request_via_purchase
     assert response = @gateway.purchase(1202, @three_ds_enrolled_card, @options.merge(payer_auth_enroll_service: true))
     assert_equal '475', response.params['reasonCode']

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -312,6 +312,16 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.success?
     assert response.test?
   end
+  
+  def test_successful_credit_card_retrieve_with_token_request
+    @gateway.stubs(:ssl_post).returns(successful_create_subscription_response, successful_retrieve_subscription_response)
+    assert response = @gateway.store(@credit_card, @subscription_options)
+    assert response.success?
+    assert response.test?
+    assert response = @gateway.retrieve_with_token(response.params["requestID"])
+    assert response.success?
+    assert response.test?
+  end
 
   def test_avs_result
     @gateway.expects(:ssl_post).returns(successful_purchase_response)


### PR DESCRIPTION
Adds `retrieve_with_token` action to retrieve subscription with subscription_id only for cybersource gateway.