### PR TITLE
[BraintreeBlue] Fix for partial updates with paypal account

### DIFF
--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -524,6 +524,26 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal customer_vault_id, response.params["braintree_customer"]["id"]
   end
 
+  def test_successful_partial_paypal_update
+    assert response = @gateway.store(paypal_account, email: "jd@example.com")
+
+    assert_success response
+    assert_equal 'OK', response.message
+    customer_vault_id = response.params["customer_vault_id"]
+    assert_match(/\A\d+\z/, customer_vault_id)
+    assert_equal "jd@example.com", response.params["braintree_customer"]["email"]
+    assert_equal "John", response.params["braintree_customer"]["first_name"]
+    assert_equal "Doe", response.params["braintree_customer"]["last_name"]
+    assert_equal customer_vault_id, response.params["braintree_customer"]["id"]
+
+    assert response = @gateway.update(customer_vault_id, paypal_account("New First", "New Last"), email: "new@example.com")
+    assert_success response
+    assert_equal "new@example.com", response.params["braintree_customer"]["email"]
+    assert_equal "New First", response.params["braintree_customer"]["first_name"]
+    assert_equal "New Last", response.params["braintree_customer"]["last_name"]
+    assert_equal customer_vault_id, response.params["braintree_customer"]["id"]
+  end
+
   def test_failed_customer_update
     assert response = @gateway.store(credit_card('4111111111111111'), :email => "email@example.com")
     assert_success response

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -163,6 +163,14 @@ module ActiveMerchant
       Billing::CreditCard.new(defaults)
     end
 
+    def paypal_account(first_name = "John", last_name = "Doe",  payment_method_nonce = "fake-paypal-future-nonce")
+      OpenStruct.new(
+        first_name: first_name,
+        last_name: last_name,
+        payment_method_nonce: payment_method_nonce,
+      )
+    end
+
     def credit_card_with_track_data(number = '4242424242424242', options = {})
       defaults = {
         :track_data => '%B' + number + '^LONGSEN/L. ^15121200000000000000**123******?',


### PR DESCRIPTION
This PR will allow partial updates for PayPal accounts with BraintreeBlue.
Partial update will happen if no `payment_method_nonce` is provided.