### PR TITLE
CyberSource: Handle IP address field in tokenized purchase requests

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -478,6 +478,14 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def add_address_ip_fields(xml, options)
+        return if options[:ip].blank?
+
+        xml.tag! 'billTo' do
+          xml.tag! 'ipAddress', options[:ip]
+        end
+      end
+
       def add_creditcard(xml, creditcard)
         xml.tag! 'card' do
           xml.tag!('accountNumber', creditcard.number) unless creditcard.number.blank?
@@ -679,6 +687,7 @@ module ActiveMerchant #:nodoc:
 
       def add_payment_method_or_subscription(xml, money, payment_method_or_reference, options)
         if payment_method_or_reference.is_a?(String)
+          add_address_ip_fields(xml, options)
           add_purchase_data(xml, money, true, options)
           add_subscription(xml, options, payment_method_or_reference)
         elsif card_brand(payment_method_or_reference) == 'check'

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -188,6 +188,18 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_successful_reference_purchase_includes_customer_ip
+    customer_ip_regexp = /<ipAddress>#{@customer_ip}<\//
+    @gateway.expects(:ssl_post).returns(successful_create_subscription_response)
+    @gateway.expects(:ssl_post).
+      with(anything, regexp_matches(customer_ip_regexp), anything).
+      returns(successful_purchase_response)
+
+    assert_success(response = @gateway.store(@credit_card, @subscription_options))
+    assert_success(@gateway.purchase(@amount, response.authorization, @options))
+    assert response.test?
+  end
+
   def test_unsuccessful_authorization
     @gateway.expects(:ssl_post).returns(unsuccessful_authorization_response)
 


### PR DESCRIPTION
While https://github.com/activemerchant/active_merchant/pull/1875 introduces the `ipAddress` field, the whole method is only used for requests that send full payment profile data and not its tokenized form (see https://github.com/chargify/active_merchant/compare/master...chargify:pgt-740-cybersource-ip-addresses#diff-ec0894a572ca922f933a687ef23008524682ccea87eec57f3175e7e1c4013bb2R688).

According to the documentation, it should be possible to pass billing address data to the tokenized purchase request, though, as https://developer.cybersource.com/library/documentation/dev_guides/CC_Svcs_SO_API/Credit_Cards_SO_API.pdf, page 212 says:

_You can override most of the information associated with the customer token by including the relevant API fields in the payment or credit request. For example, you could provide a different  billing or shipping address in the request. You cannot override the payment card account number._

While it'd be ideal to introduce the ability to do that, it'd require a bigger refactoring. The current logic treats lack of some params as if the params should not be added while lack of some other params as if they should be added with a nil value. In case of the tokenized purchase, the passed billing address should be more of a "patch" than a "put" so that we don't require the whole address to be passed each time, but rather only the fields that need to be updated.

That's why I ended up implementing the `ipAddress` part of the billing address only.

![test_pass](https://user-images.githubusercontent.com/7498713/99247409-355b7380-2807-11eb-86f9-812e1aeb3115.png)

![ebc](https://user-images.githubusercontent.com/7498713/99248803-5755f580-2809-11eb-9b6f-5c9a142b0c97.png)




