### PR TITLE
[feature] Add support for offline customer_acceptance when creating setup_intents

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -773,14 +773,21 @@ module ActiveMerchant #:nodoc:
           confirm: true,
           mandate_data: {
             customer_acceptance: {
-              type: "online",
-              online: {
-                ip_address: options.dig(:device_data, :ip),
-                user_agent: options.dig(:device_data, :user_agent)
-              }
             }
           }
         }
+
+        if options[:channel] == "api"
+          post[:mandate_data][:customer_acceptance] = { type: "offline" }
+        else
+          post[:mandate_data][:customer_acceptance] = {
+            type: "online",
+            online: {
+              ip_address: options.dig(:device_data, :ip),
+              user_agent: options.dig(:device_data, :user_agent)
+            }
+          }
+        end
 
         token_response = api_request(:post, "setup_intents", post)
         success = token_response["error"].nil?

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -744,6 +744,16 @@ module ActiveMerchant #:nodoc:
           }
         }
 
+        if address = options[:billing_address] || options[:address]
+          post[:billing_details][:address] = {}
+          post[:billing_details][:address][:line1] = address[:address1] if address[:address1]
+          post[:billing_details][:address][:line2] = address[:address2] if address[:address2]
+          post[:billing_details][:address][:country] = address[:country] if address[:country]
+          post[:billing_details][:address][:postal_code] = address[:zip] if address[:zip]
+          post[:billing_details][:address][:state] = address[:state] if address[:state]
+          post[:billing_details][:address][:city] = address[:city] if address[:city]
+        end
+
         token_response = api_request(:post, "payment_methods", post)
         success = token_response["error"].nil?
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -320,7 +320,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if options[:three_d_secure]
-          payment_method = card_payment_method_for_customer(options[:customer])
+          payment_method = card_payment_method_for_customer(options[:customer], options[:payment_type])
 
           if payment_method
             post[:confirmation_method] = "manual"
@@ -353,13 +353,15 @@ module ActiveMerchant #:nodoc:
         post
       end
 
-      def card_payment_method_for_customer(customer)
+      def card_payment_method_for_customer(customer, payment_type)
         # if customer has only one payment method we choose that one
         r = commit(:get, "payment_methods?customer=#{customer}&type=card", nil, options)
         raise r.message unless r.success?
 
-        r = commit(:get, "payment_methods?customer=#{customer}&type=sepa_debit", nil, options)
-        raise r.message unless r.success?
+        if payment_type == "bank_account"
+          r = commit(:get, "payment_methods?customer=#{customer}&type=sepa_debit", nil, options)
+          raise r.message unless r.success?
+        end
 
         payment_methods = r.params["data"]
         return payment_methods[0]["id"] if payment_methods&.count == 1

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -233,7 +233,7 @@ module ActiveMerchant #:nodoc:
           if params[:payment_method_id].present?
             MultiResponse.run(:first) do |r|
               r.process { commit(:post, 'customers', post.merge(params.except(:payment_method_id)), options) }
-              r.process { setup_intents(r.responses.last.authorization.split("|").first, params[:payment_method_id]) }
+              r.process { setup_intents(r.responses.last.authorization.split("|").first, params[:payment_method_id], options) }
             end
           else
             commit(:post, 'customers', post.merge(params.except(:payment_method_id)), options)
@@ -735,7 +735,7 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def setup_intents(customer_id, payment_method_id)
+      def setup_intents(customer_id, payment_method_id, options)
         post = {
           payment_method_types: ["sepa_debit"],
           customer: customer_id,
@@ -745,8 +745,8 @@ module ActiveMerchant #:nodoc:
             customer_acceptance: {
               type: "online",
               online: {
-                ip_address: "127.0.0.1",
-                user_agent: "Firefox"
+                ip_address: options.dig(:device_data, :ip),
+                user_agent: options.dig(:device_data, :user_agent)
               }
             }
           }

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -393,6 +393,7 @@ module ActiveMerchant #:nodoc:
         payment_methods = r.params["data"]
         return payment_methods[0]["id"] if payment_methods&.count == 1
 
+        r = commit(:get, "customers/#{customer}", nil, options)
         # if customer has default payment method
         default_payment_method = r.params.dig("invoice_settings", "default_payment_method")
         return default_payment_method if default_payment_method


### PR DESCRIPTION
This will add support for creating setup intents with customer_acceptance being set as offline.