### PR TITLE
Update CyberSource subsequent auth logic

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -731,15 +731,15 @@ module ActiveMerchant #:nodoc:
       def add_stored_credential_subsequent_auth(xml, options = {})
         return unless options[:stored_credential]
 
-        xml.subsequentAuth 'true' if options.dig(:stored_credential, :initiator) == 'merchant'
+        xml.tag! 'subsequentAuth', 'true' if options.dig(:stored_credential, :initiator) == 'merchant'
       end
 
       # Temporary fix, revert and cherry-pick commits from the upstream AM
       def add_stored_credential_options(xml, options = {})
         return unless options[:stored_credential]
 
-        xml.subsequentAuthFirst 'true' if options.dig(:stored_credential, :initial_transaction)
-        xml.subsequentAuthTransactionID options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
+        xml.tag! 'subsequentAuthFirst', 'true' if options.dig(:stored_credential, :initial_transaction)
+        xml.tag! 'subsequentAuthTransactionID', options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
       end
 
       # Where we actually build the full SOAP request using builder

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -263,6 +263,7 @@ module ActiveMerchant #:nodoc:
         add_threeds_services(xml, options)
         add_payment_network_token(xml) if network_tokenization?(creditcard_or_reference)
         add_business_rules_data(xml, creditcard_or_reference, options)
+        add_stored_credential_subsequent_auth(xml, options)
         add_stored_credential_options(xml, options)
         xml.target!
       end
@@ -302,6 +303,7 @@ module ActiveMerchant #:nodoc:
           add_payment_network_token(xml) if network_tokenization?(payment_method_or_reference)
           add_business_rules_data(xml, payment_method_or_reference, options) unless options[:pinless_debit_card]
         end
+        add_stored_credential_subsequent_auth(xml, options)
         add_stored_credential_options(xml, options)
         xml.target!
       end
@@ -725,16 +727,19 @@ module ActiveMerchant #:nodoc:
         country_code&.code(:alpha2)
       end
 
-      def add_stored_credential_options(xml, options={})
+      # Temporary fix, revert and cherry-pick commits from the upstream AM
+      def add_stored_credential_subsequent_auth(xml, options = {})
         return unless options[:stored_credential]
-        if options[:stored_credential][:initial_transaction]
-          xml.tag! 'subsequentAuthFirst', 'true'
-        elsif options[:stored_credential][:reason_type] == 'unscheduled'
-          xml.tag! 'subsequentAuth', 'true'
-          xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
-        else
-          xml.tag! 'subsequentAuthTransactionID', options[:stored_credential][:network_transaction_id]
-        end
+
+        xml.subsequentAuth 'true' if options.dig(:stored_credential, :initiator) == 'merchant'
+      end
+
+      # Temporary fix, revert and cherry-pick commits from the upstream AM
+      def add_stored_credential_options(xml, options = {})
+        return unless options[:stored_credential]
+
+        xml.subsequentAuthFirst 'true' if options.dig(:stored_credential, :initial_transaction)
+        xml.subsequentAuthTransactionID options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
       end
 
       # Where we actually build the full SOAP request using builder


### PR DESCRIPTION
In this PR I'm copying some logic from [the upstream AM](https://github.com/activemerchant/active_merchant/blob/3d7841d9c232a7ebed0c3f74cd4598576749030e/lib/active_merchant/billing/gateways/cyber_source.rb#L887) to fix issues with subsequentAuth payments.
Updating our AM so that it contains the same commits is a bigger task - there are more changes to the three ds fields as well as a SOAP schema change. I'd like to do that at a later time, once the current merchant issues are resolved.

I couldn't make all the tests pass locally but I can confirm these changes don't affect the test run, see screenshots before.

CyberSource remote tests before:
![Screenshot 2021-03-18 at 12 16 09](https://user-images.githubusercontent.com/7498713/111618489-bb52ef80-87e4-11eb-92e2-31f035c1b980.png)

CyberSource remote tests now:
![Screenshot 2021-03-19 at 12 02 38](https://user-images.githubusercontent.com/7498713/111771110-8fe70800-88ab-11eb-8793-6b7f3cdd3630.png)

CyberSource unit tests now:
![Screenshot 2021-03-18 at 12 22 22](https://user-images.githubusercontent.com/7498713/111618541-c9087500-87e4-11eb-8cc8-890195436155.png)
