### PR TITLE
[feature] Add statement descriptor for NMI

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -34,6 +34,7 @@ module ActiveMerchant #:nodoc:
         add_customer_data(post, options)
         add_merchant_defined_fields(post, options)
         add_stored_credentials_options(post, options)
+        add_descriptor(post, options)
 
         commit("sale", post)
       end
@@ -214,6 +215,12 @@ module ActiveMerchant #:nodoc:
         end
 
         post[:initial_transaction_id] = stored_credential[:network_transaction_id]
+      end
+
+      def add_descriptor(post, options)
+        return unless options[:descriptor]
+
+        post[:descriptor] = options[:descriptor]
       end
 
       def exp_date(payment_method)

--- a/test/remote/gateways/remote_nmi_test.rb
+++ b/test/remote/gateways/remote_nmi_test.rb
@@ -31,6 +31,14 @@ class RemoteNmiTest < Test::Unit::TestCase
     assert response.authorization
   end
 
+  def test_successful_purchase_with_descriptor
+    assert response = @gateway.purchase(@amount, @credit_card, @options.merge(descriptor: 'trial end'))
+    assert_success response
+    assert response.test?
+    assert_equal 'Succeeded', response.message
+    assert response.authorization
+  end
+
   def test_successful_purchase_sans_cvv
     @credit_card.verification_value = nil
     assert response = @gateway.purchase(@amount, @credit_card, @options)

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -51,6 +51,18 @@ class NmiTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_purchase_with_descriptor_includes_descriptor
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, descriptor: 'trial end')
+    end.check_request do |endpoint, data, headers|
+      assert_match(/descriptor=trial\+end/, data)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert response.test?
+    assert_equal "2762757839#creditcard", response.authorization
+  end
+
   def test_failed_purchase
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card)


### PR DESCRIPTION
This will add support for the statement descriptor in NMI.

### Why:
**Summary for requirement:**

Merchants must add a descriptor that indicates a transaction related to a trial offer to the first transaction processed after the trial offer ends. This descriptor should be added to the Merchant Name field of the Clearing Record and should include language like “trial,” “trial period,” “free trial,” and the like. This will then appear on bank statements, banking apps, and text alerts that the cardholder sees.

**What is the enhanced descriptor for? Where is it required? ([Visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/subscription-policy-vbn-visa-public.pdf))**

The enhanced descriptor (e.g., “trial,” “trial period,” “free trial”) is to be included in the Merchant Name field of the clearing record for the first transaction at the end of a trial period. It is not required for subsequent transactions. This descriptor will then appear on cardholder statements, online banking, mobile apps and SMS / text alerts, in the same way discretionary data or additional invoice / order numbers appear for e-commerce transactions today, to identify the nature of the transaction. Visa is not restricting the word choice of the enhanced descriptor, as long as the merchant can identify that it is a trial-related transaction for the cardholder and issuer.

**Additional info from [visa](https://usa.visa.com/dam/VCOM/global/support-legal/documents/visa-new-subscription-rules-flier.pdf)**

Statement Descriptor An additional descriptor indicating a trial period-related transaction will be required in the Merchant Name field of the Clearing Record for the first transaction at the end of a trial period. This descriptor (for example, “trial,” “trial period,” “free trial”) will then appear on cardholder statements, online banking, mobile apps, and SMS/text alerts, in the same way discretionary, additional invoice/order numbers appear for electronic commerce transactions.


### What:

For NMI you can submit the dynamic description in a payment request by submitting the [descriptor] (https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#transaction_variables) field