### PR TITLE
[Internal] Support for stored credentials for Litle gateway (as a new gateway)

### DIFF
--- a/lib/active_merchant/billing/gateways/litle_new.rb
+++ b/lib/active_merchant/billing/gateways/litle_new.rb
@@ -1,0 +1,539 @@
+require 'nokogiri'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    class LitleNewGateway < Gateway
+      SCHEMA_VERSION = '9.14'
+
+      class_attribute :pre_live_url
+
+      self.test_url = 'https://www.testvantivcnp.com/sandbox/communicator/online'
+      self.pre_live_url = 'https://payments.vantivprelive.com/vap/communicator/online'
+      self.live_url = 'https://payments.vantivcnp.com/vap/communicator/online'
+
+      self.supported_countries = ['US']
+      self.default_currency = 'USD'
+      self.supported_cardtypes = %i[visa master american_express discover diners_club jcb]
+
+      self.homepage_url = 'http://www.vantiv.com/'
+      self.display_name = 'Vantiv eCommerce'
+
+      def initialize(options = {})
+        requires!(options, :login, :password, :merchant_id)
+        super
+      end
+
+      def purchase(money, payment_method, options = {})
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          if check?(payment_method)
+            doc.echeckSale(transaction_attributes(options)) do
+              add_echeck_purchase_params(doc, money, payment_method, options)
+            end
+          else
+            doc.sale(transaction_attributes(options)) do
+              add_auth_purchase_params(doc, money, payment_method, options)
+            end
+          end
+        end
+        check?(payment_method) ? commit(:echeckSales, request, money) : commit(:sale, request, money)
+      end
+
+      def authorize(money, payment_method, options = {})
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          if check?(payment_method)
+            doc.echeckVerification(transaction_attributes(options)) do
+              add_echeck_purchase_params(doc, money, payment_method, options)
+            end
+          else
+            doc.authorization(transaction_attributes(options)) do
+              add_auth_purchase_params(doc, money, payment_method, options)
+            end
+          end
+        end
+        check?(payment_method) ? commit(:echeckVerification, request, money) : commit(:authorization, request, money)
+      end
+
+      def capture(money, authorization, options = {})
+        transaction_id, = split_authorization(authorization)
+
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          add_descriptor(doc, options)
+          doc.capture_(transaction_attributes(options)) do
+            doc.litleTxnId(transaction_id)
+            doc.amount(money) if money
+          end
+        end
+
+        commit(:capture, request, money)
+      end
+
+      def credit(money, authorization, options = {})
+        ActiveMerchant.deprecated CREDIT_DEPRECATION_MESSAGE
+        refund(money, authorization, options)
+      end
+
+      def refund(money, payment, options = {})
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          add_descriptor(doc, options)
+          doc.send(refund_type(payment), transaction_attributes(options)) do
+            if payment.is_a?(String)
+              transaction_id, = split_authorization(payment)
+              doc.litleTxnId(transaction_id)
+              doc.amount(money) if money
+            elsif check?(payment)
+              add_echeck_purchase_params(doc, money, payment, options)
+            else
+              add_credit_params(doc, money, payment, options)
+            end
+          end
+        end
+
+        commit(refund_type(payment), request)
+      end
+
+      def verify(creditcard, options = {})
+        MultiResponse.run(:use_first_response) do |r|
+          r.process { authorize(0, creditcard, options) }
+          r.process(:ignore_result) { void(r.authorization, options) }
+        end
+      end
+
+      def void(authorization, options = {})
+        transaction_id, kind, money = split_authorization(authorization)
+
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          doc.send(void_type(kind), transaction_attributes(options)) do
+            doc.litleTxnId(transaction_id)
+            doc.amount(money) if void_type(kind) == :authReversal
+          end
+        end
+
+        commit(void_type(kind), request)
+      end
+
+      def store(payment_method, options = {})
+        request = build_xml_request do |doc|
+          add_authentication(doc)
+          doc.registerTokenRequest(transaction_attributes(options)) do
+            doc.orderId(truncate(options[:order_id], 24))
+            if payment_method.is_a?(String)
+              doc.paypageRegistrationId(payment_method)
+            elsif check?(payment_method)
+              doc.echeckForToken do
+                doc.accNum(payment_method.account_number)
+                doc.routingNum(payment_method.routing_number)
+              end
+            else
+              doc.accountNumber(payment_method.number)
+              doc.cardValidationNum(payment_method.verification_value) if payment_method.verification_value
+            end
+          end
+        end
+
+        commit(:registerToken, request)
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript.
+          gsub(%r((<user>).+(</user>)), '\1[FILTERED]\2').
+          gsub(%r((<password>).+(</password>)), '\1[FILTERED]\2').
+          gsub(%r((<number>).+(</number>)), '\1[FILTERED]\2').
+          gsub(%r((<accNum>).+(</accNum>)), '\1[FILTERED]\2').
+          gsub(%r((<routingNum>).+(</routingNum>)), '\1[FILTERED]\2').
+          gsub(%r((<cardValidationNum>).+(</cardValidationNum>)), '\1[FILTERED]\2').
+          gsub(%r((<accountNumber>).+(</accountNumber>)), '\1[FILTERED]\2').
+          gsub(%r((<paypageRegistrationId>).+(</paypageRegistrationId>)), '\1[FILTERED]\2').
+          gsub(%r((<authenticationValue>).+(</authenticationValue>)), '\1[FILTERED]\2')
+      end
+
+      private
+
+      CARD_TYPE = {
+        'visa'             => 'VI',
+        'master'           => 'MC',
+        'american_express' => 'AX',
+        'discover'         => 'DI',
+        'jcb'              => 'JC',
+        'diners_club'      => 'DC'
+      }
+
+      AVS_RESPONSE_CODE = {
+        '00' => 'Y',
+        '01' => 'X',
+        '02' => 'D',
+        '10' => 'Z',
+        '11' => 'W',
+        '12' => 'A',
+        '13' => 'A',
+        '14' => 'P',
+        '20' => 'N',
+        '30' => 'S',
+        '31' => 'R',
+        '32' => 'U',
+        '33' => 'R',
+        '34' => 'I',
+        '40' => 'E'
+      }
+
+      def void_type(kind)
+        if kind == 'authorization'
+          :authReversal
+        elsif kind == 'echeckSales'
+          :echeckVoid
+        else
+          :void
+        end
+      end
+
+      def refund_type(payment)
+        _, kind, = split_authorization(payment)
+        if check?(payment) || kind == 'echeckSales'
+          :echeckCredit
+        else
+          :credit
+        end
+      end
+
+      def check?(payment_method)
+        return false if payment_method.is_a?(String)
+
+        card_brand(payment_method) == 'check'
+      end
+
+      def add_authentication(doc)
+        doc.authentication do
+          doc.user(@options[:login])
+          doc.password(@options[:password])
+        end
+      end
+
+      def add_auth_purchase_params(doc, money, payment_method, options)
+        doc.orderId(truncate(options[:order_id], 24))
+        doc.amount(money)
+        add_order_source(doc, payment_method, options)
+        add_billing_address(doc, payment_method, options)
+        add_shipping_address(doc, payment_method, options)
+        add_payment_method(doc, payment_method, options)
+        add_pos(doc, payment_method)
+        add_descriptor(doc, options)
+        add_merchant_data(doc, options)
+        add_debt_repayment(doc, options)
+        add_stored_credential_params(doc, options)
+      end
+
+      def add_credit_params(doc, money, payment_method, options)
+        doc.orderId(truncate(options[:order_id], 24))
+        doc.amount(money)
+        add_order_source(doc, payment_method, options)
+        add_billing_address(doc, payment_method, options)
+        add_payment_method(doc, payment_method, options)
+        add_pos(doc, payment_method)
+        add_descriptor(doc, options)
+        add_merchant_data(doc, options)
+      end
+
+      def add_merchant_data(doc, options = {})
+        if options[:affiliate] || options[:campaign] || options[:merchant_grouping_id]
+          doc.merchantData do
+            doc.affiliate(options[:affiliate]) if options[:affiliate]
+            doc.campaign(options[:campaign]) if options[:campaign]
+            doc.merchantGroupingId(options[:merchant_grouping_id]) if options[:merchant_grouping_id]
+          end
+        end
+      end
+
+      def add_echeck_purchase_params(doc, money, payment_method, options)
+        doc.orderId(truncate(options[:order_id], 24))
+        doc.amount(money)
+        add_order_source(doc, payment_method, options)
+        add_billing_address(doc, payment_method, options)
+        add_payment_method(doc, payment_method, options)
+        add_descriptor(doc, options)
+      end
+
+      def add_descriptor(doc, options)
+        if options[:descriptor_name] || options[:descriptor_phone]
+          doc.customBilling do
+            doc.phone(options[:descriptor_phone]) if options[:descriptor_phone]
+            doc.descriptor(options[:descriptor_name]) if options[:descriptor_name]
+          end
+        end
+      end
+
+      def add_debt_repayment(doc, options)
+        doc.debtRepayment(true) if options[:debt_repayment] == true
+      end
+
+      def add_payment_method(doc, payment_method, options)
+        if payment_method.is_a?(String)
+          doc.token do
+            doc.litleToken(payment_method)
+            doc.expDate(format_exp_date(options[:basis_expiration_month], options[:basis_expiration_year])) if options[:basis_expiration_month] && options[:basis_expiration_year]
+          end
+        elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
+          doc.card do
+            doc.track(payment_method.track_data)
+          end
+        elsif check?(payment_method)
+          doc.echeck do
+            doc.accType(payment_method.account_type.capitalize)
+            doc.accNum(payment_method.account_number)
+            doc.routingNum(payment_method.routing_number)
+            doc.checkNum(payment_method.number) if payment_method.number
+          end
+        else
+          doc.card do
+            doc.type_(CARD_TYPE[payment_method.brand])
+            doc.number(payment_method.number)
+            doc.expDate(exp_date(payment_method))
+            doc.cardValidationNum(payment_method.verification_value)
+          end
+          if payment_method.is_a?(NetworkTokenizationCreditCard)
+            doc.cardholderAuthentication do
+              doc.authenticationValue(payment_method.payment_cryptogram)
+            end
+          elsif options[:order_source]&.start_with?('3ds')
+            doc.cardholderAuthentication do
+              doc.authenticationValue(options[:cavv]) if options[:cavv]
+              doc.authenticationTransactionId(options[:xid]) if options[:xid]
+            end
+          end
+        end
+      end
+
+      def add_stored_credential_params(doc, options = {})
+        return unless options[:stored_credential]
+
+        if options[:stored_credential][:initial_transaction]
+          add_stored_credential_params_initial(doc, options)
+        else
+          add_stored_credential_params_used(doc, options)
+        end
+      end
+
+      def add_stored_credential_params_initial(doc, options)
+        case options[:stored_credential][:reason_type]
+        when 'unscheduled'
+          doc.processingType('initialCOF')
+        when 'installment'
+          doc.processingType('initialInstallment')
+        when 'recurring'
+          doc.processingType('initialRecurring')
+        end
+      end
+
+      def add_stored_credential_params_used(doc, options)
+        if options[:stored_credential][:reason_type] == 'unscheduled'
+          if options[:stored_credential][:initiator] == 'merchant'
+            doc.processingType('merchantInitiatedCOF')
+          else
+            doc.processingType('cardholderInitiatedCOF')
+          end
+        end
+        doc.originalNetworkTransactionId(options[:stored_credential][:network_transaction_id])
+      end
+
+      def add_billing_address(doc, payment_method, options)
+        return if payment_method.is_a?(String)
+
+        doc.billToAddress do
+          if check?(payment_method)
+            doc.name(payment_method.name)
+            doc.firstName(payment_method.first_name)
+            doc.lastName(payment_method.last_name)
+          else
+            doc.name(payment_method.name)
+          end
+          doc.email(options[:email]) if options[:email]
+
+          add_address(doc, options[:billing_address])
+        end
+      end
+
+      def add_shipping_address(doc, payment_method, options)
+        return if payment_method.is_a?(String)
+
+        doc.shipToAddress do
+          add_address(doc, options[:shipping_address])
+        end
+      end
+
+      def add_address(doc, address)
+        return unless address
+
+        doc.companyName(address[:company]) unless address[:company].blank?
+        doc.addressLine1(address[:address1]) unless address[:address1].blank?
+        doc.addressLine2(address[:address2]) unless address[:address2].blank?
+        doc.city(address[:city]) unless address[:city].blank?
+        doc.state(address[:state]) unless address[:state].blank?
+        doc.zip(address[:zip]) unless address[:zip].blank?
+        doc.country(address[:country]) unless address[:country].blank?
+        doc.phone(address[:phone]) unless address[:phone].blank?
+      end
+
+      def add_order_source(doc, payment_method, options)
+        order_source = order_source(options)
+        if order_source
+          doc.orderSource(order_source)
+        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :apple_pay
+          doc.orderSource('applepay')
+        elsif payment_method.is_a?(NetworkTokenizationCreditCard) && payment_method.source == :android_pay
+          doc.orderSource('androidpay')
+        elsif payment_method.respond_to?(:track_data) && payment_method.track_data.present?
+          doc.orderSource('retail')
+        else
+          doc.orderSource('ecommerce')
+        end
+      end
+
+      def order_source(options = {})
+        return options[:order_source] unless options[:stored_credential]
+
+        order_source = nil
+
+        case options[:stored_credential][:reason_type]
+        when 'unscheduled'
+          if options[:stored_credential][:initiator] == 'merchant'
+            # For merchant-initiated, we should always set order source to
+            # 'ecommerce'
+            order_source = 'ecommerce'
+          else
+            # For cardholder-initiated, we rely on #add_order_source's
+            # default logic to set orderSource appropriately
+            order_source = options[:order_source]
+          end
+        when 'installment'
+          order_source = 'installment'
+        when 'recurring'
+          order_source = 'recurring'
+        end
+
+        order_source
+      end
+
+      def add_pos(doc, payment_method)
+        return unless payment_method.respond_to?(:track_data) && payment_method.track_data.present?
+
+        doc.pos do
+          doc.capability('magstripe')
+          doc.entryMode('completeread')
+          doc.cardholderId('signature')
+        end
+      end
+
+      def exp_date(payment_method)
+        format_exp_date(payment_method.month, payment_method.year)
+      end
+
+      def format_exp_date(month, year)
+        "#{format(month, :two_digits)}#{format(year, :two_digits)}"
+      end
+
+      def parse(kind, xml)
+        parsed = {}
+
+        doc = Nokogiri::XML(xml).remove_namespaces!
+        doc.xpath("//litleOnlineResponse/#{kind}Response/*").each do |node|
+          if node.elements.empty?
+            parsed[node.name.to_sym] = node.text
+          else
+            node.elements.each do |childnode|
+              name = "#{node.name}_#{childnode.name}"
+              parsed[name.to_sym] = childnode.text
+            end
+          end
+        end
+
+        if parsed.empty?
+          %w(response message).each do |attribute|
+            parsed[attribute.to_sym] = doc.xpath('//litleOnlineResponse').attribute(attribute).value
+          end
+        end
+
+        parsed
+      end
+
+      def commit(kind, request, money = nil)
+        parsed = parse(kind, ssl_post(url, request, headers))
+
+        options = {
+          authorization: authorization_from(kind, parsed, money),
+          test: test?,
+          avs_result: { code: AVS_RESPONSE_CODE[parsed[:fraudResult_avsResult]] },
+          cvv_result: parsed[:fraudResult_cardValidationResult]
+        }
+
+        Response.new(success_from(kind, parsed), parsed[:message], parsed, options)
+      end
+
+      def success_from(kind, parsed)
+        return (parsed[:response] == '000') unless kind == :registerToken
+
+        %w(000 801 802).include?(parsed[:response])
+      end
+
+      def authorization_from(kind, parsed, money)
+        kind == :registerToken ? parsed[:litleToken] : "#{parsed[:litleTxnId]};#{kind};#{money}"
+      end
+
+      def split_authorization(authorization)
+        transaction_id, kind, money = authorization.to_s.split(';')
+        [transaction_id, kind, money]
+      end
+
+      def transaction_attributes(options)
+        attributes = {}
+        attributes[:id] = truncate(options[:id] || options[:order_id], 24)
+        attributes[:reportGroup] = options[:merchant] || 'Default Report Group'
+        attributes[:customerId] = options[:customer]
+        attributes.delete_if { |_key, value| value == nil }
+        attributes
+      end
+
+      def root_attributes
+        {
+          merchantId: @options[:merchant_id],
+          version: SCHEMA_VERSION,
+          xmlns: 'http://www.litle.com/schema'
+        }
+      end
+
+      def build_xml_request
+        builder = Nokogiri::XML::Builder.new
+        builder.__send__('litleOnlineRequest', root_attributes) do |doc|
+          yield(doc)
+        end
+        builder.doc.root.to_xml
+      end
+
+      def url
+        if test? && has_credentials?
+          pre_live_url
+        elsif test?
+          test_url
+        else
+          live_url
+        end
+      end
+
+      def has_credentials?
+        @options[:login].present? && @options[:password].present?
+      end
+
+      def headers
+        {
+          'Content-Type' => 'text/xml'
+        }
+      end
+    end
+  end
+end

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -465,6 +465,11 @@ litle:
   password: MERCHANT
   merchant_id: 101
 
+litle_new:
+  login: ""
+  password: ""
+  merchant_id: 101
+
 # Working test credentials, no need to replace
 maxipago:
   login: "100"

--- a/test/remote/gateways/remote_litle_new_certification_test.rb
+++ b/test/remote/gateways/remote_litle_new_certification_test.rb
@@ -1,0 +1,1250 @@
+require 'test_helper'
+
+class RemoteLitleNewCertification < Test::Unit::TestCase
+  def setup
+    Base.mode = :test
+    @gateway = LitleNewGateway.new(fixtures(:litle_new))
+    @gateway.test_url = 'https://payments.vantivprelive.com/vap/communicator/online'
+  end
+
+  def test1
+    credit_card = CreditCard.new(
+      number: '4457010000000009',
+      month: '01',
+      year: '2021',
+      verification_value: '349',
+      brand: 'visa'
+    )
+
+    options = {
+      order_id: '1',
+      billing_address: {
+        name: 'John & Mary Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
+      }
+    }
+
+    auth_assertions(10100, credit_card, options, avs: 'X', cvv: 'M')
+
+    authorize_avs_assertions(credit_card, options, avs: 'X', cvv: 'M')
+
+    sale_assertions(10100, credit_card, options, avs: 'X', cvv: 'M')
+  end
+
+  def test2
+    credit_card = CreditCard.new(number: '5112010000000003', month: '02',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '261',
+                                 name: 'Mike J. Hammer')
+
+    options = {
+      order_id: '2',
+      billing_address: {
+        address1: '2 Main St.',
+        address2: 'Apt. 222',
+        city: 'Riverside',
+        state: 'RI',
+        zip: '02915',
+        country: 'US'
+      }
+    }
+
+    auth_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
+
+    authorize_avs_assertions(credit_card, options, avs: 'Z', cvv: 'M')
+
+    sale_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
+  end
+
+  def test3
+    credit_card = CreditCard.new(
+      number: '6011010000000003',
+      month: '03',
+      year: '2021',
+      verification_value: '758',
+      brand: 'discover'
+    )
+
+    options = {
+      order_id: '3',
+      billing_address: {
+        name: 'Eileen Jones',
+        address1: '3 Main St.',
+        city: 'Bloomfield',
+        state: 'CT',
+        zip: '06002',
+        country: 'US'
+      }
+    }
+    auth_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
+
+    authorize_avs_assertions(credit_card, options, avs: 'Z', cvv: 'M')
+
+    sale_assertions(10100, credit_card, options, avs: 'Z', cvv: 'M')
+  end
+
+  def test4
+    credit_card = CreditCard.new(
+      number: '375001000000005',
+      month: '04',
+      year: '2021',
+      brand: 'american_express'
+    )
+
+    options = {
+      order_id: '4',
+      billing_address: {
+        name: 'Bob Black',
+        address1: '4 Main St.',
+        city: 'Laurel',
+        state: 'MD',
+        zip: '20708',
+        country: 'US'
+      }
+    }
+
+    auth_assertions(10100, credit_card, options, avs: 'A', cvv: nil)
+
+    authorize_avs_assertions(credit_card, options, avs: 'A')
+
+    sale_assertions(10100, credit_card, options, avs: 'A', cvv: nil)
+  end
+
+  def test5
+    credit_card = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      number: '4100200300011001',
+      month: '05',
+      year: '2021',
+      verification_value: '463',
+      brand: 'visa',
+      payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+    )
+
+    options = {
+      order_id: '5'
+    }
+
+    auth_assertions(10100, credit_card, options, avs: 'U', cvv: 'M')
+
+    authorize_avs_assertions(credit_card, options, avs: 'U', cvv: 'M')
+
+    sale_assertions(10100, credit_card, options, avs: 'U', cvv: 'M')
+  end
+
+  def test6
+    credit_card = CreditCard.new(number: '4457010100000008', month: '06',
+                                 year: '2021', brand: 'visa',
+                                 verification_value: '992')
+
+    options = {
+      order_id: '6',
+      billing_address: {
+        name: 'Joe Green',
+        address1: '6 Main St.',
+        city: 'Derry',
+        state: 'NH',
+        zip: '03038',
+        country: 'US'
+      }
+    }
+
+    # 6: authorize
+    assert response = @gateway.authorize(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '110', response.params['response']
+    assert_equal 'Insufficient Funds', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'P', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
+
+    # 6. sale
+    assert response = @gateway.purchase(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '110', response.params['response']
+    assert_equal 'Insufficient Funds', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'P', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+
+    # 6A. void
+    assert response = @gateway.void(response.authorization, { order_id: '6A' })
+    assert_equal '360', response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', response.message
+    puts "Test #{options[:order_id]}A: #{txn_id(response)}"
+  end
+
+  def test7
+    credit_card = CreditCard.new(number: '5112010100000002', month: '07',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '251')
+
+    options = {
+      order_id: '7',
+      billing_address: {
+        name: 'Jane Murray',
+        address1: '7 Main St.',
+        city: 'Amesbury',
+        state: 'MA',
+        zip: '01913',
+        country: 'US'
+      }
+    }
+
+    # 7: authorize
+    assert response = @gateway.authorize(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '301', response.params['response']
+    assert_equal 'Invalid Account Number', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'N', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
+
+    # 7: authorize avs
+    authorize_avs_assertions(credit_card, options, avs: 'I', cvv: 'N', message: 'Invalid Account Number', success: false)
+
+    # 7. sale
+    assert response = @gateway.purchase(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '301', response.params['response']
+    assert_equal 'Invalid Account Number', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'N', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+  end
+
+  def test8
+    credit_card = CreditCard.new(number: '6011010100000002', month: '08',
+                                 year: '2021', brand: 'discover',
+                                 verification_value: '184')
+
+    options = {
+      order_id: '8',
+      billing_address: {
+        name: 'Mark Johnson',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US'
+      }
+    }
+
+    # 8: authorize
+    assert response = @gateway.authorize(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '123', response.params['response']
+    assert_equal 'Call Discover', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'P', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
+
+    # 8: authorize avs
+    authorize_avs_assertions(credit_card, options, avs: 'I', cvv: 'P', message: 'Call Discover', success: false)
+
+    # 8: sale
+    assert response = @gateway.purchase(80080, credit_card, options)
+    assert !response.success?
+    assert_equal '123', response.params['response']
+    assert_equal 'Call Discover', response.message
+    assert_equal 'I', response.avs_result['code']
+    assert_equal 'P', response.cvv_result['code']
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+  end
+
+  def test9
+    credit_card = CreditCard.new(number: '375001010000003', month: '09',
+                                 year: '2021', brand: 'american_express',
+                                 verification_value: '0421')
+
+    options = {
+      order_id: '9',
+      billing_address: {
+        name: 'James Miller',
+        address1: '9 Main St.',
+        city: 'Boston',
+        state: 'MA',
+        zip: '02134',
+        country: 'US'
+      }
+    }
+
+    # 9: authorize
+    assert response = @gateway.authorize(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '303', response.params['response']
+    assert_equal 'Pick Up Card', response.message
+    assert_equal 'I', response.avs_result['code']
+    puts "Test #{options[:order_id]} Authorize: #{txn_id(response)}"
+
+    # 9: authorize avs
+    authorize_avs_assertions(credit_card, options, avs: 'I', message: 'Pick Up Card', success: false)
+
+    # 9: sale
+    assert response = @gateway.purchase(10100, credit_card, options)
+    assert !response.success?
+    assert_equal '303', response.params['response']
+    assert_equal 'Pick Up Card', response.message
+    assert_equal 'I', response.avs_result['code']
+    puts "Test #{options[:order_id]} Sale: #{txn_id(response)}"
+  end
+
+  # Authorization Reversal Tests
+  def test32
+    credit_card = CreditCard.new(number: '4457010000000009', month: '01',
+                                 year: '2021', brand: 'visa',
+                                 verification_value: '349')
+
+    options = {
+      order_id: '32',
+      billing_address: {
+        name: 'John Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
+      }
+    }
+
+    assert auth_response = @gateway.authorize(10010, credit_card, options)
+    assert_success auth_response
+    assert_equal '11111 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert capture_response = @gateway.capture(5050, auth_response.authorization, options)
+    assert_success capture_response
+    puts "Test #{options[:order_id]}A: #{txn_id(capture_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Authorization amount has already been depleted', reversal_response.message
+    puts "Test #{options[:order_id]}B: #{txn_id(reversal_response)}"
+  end
+
+  def test33
+    credit_card = CreditCard.new(number: '5112010000000003', month: '01',
+                                 year: '2021', brand: 'master',
+                                 verification_value: '261')
+
+    options = {
+      order_id: '33',
+      billing_address: {
+        name: 'Mike J. Hammer',
+        address1: '2 Main St.',
+        address2: 'Apt. 222',
+        city: 'Riverside',
+        state: 'RI',
+        zip: '02915',
+        country: 'US',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    }
+
+    assert auth_response = @gateway.authorize(20020, credit_card, options)
+    assert_success auth_response
+    assert_equal '22222 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_success reversal_response
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
+  end
+
+  def test34
+    credit_card = CreditCard.new(number: '6011010000000003', month: '01',
+                                 year: '2021', brand: 'discover',
+                                 verification_value: '758')
+
+    options = {
+      order_id: '34',
+      billing_address: {
+        name: 'Eileen Jones',
+        address1: '3 Main St.',
+        city: 'Bloomfield',
+        state: 'CT',
+        zip: '06002',
+        country: 'US'
+      }
+    }
+
+    assert auth_response = @gateway.authorize(30030, credit_card, options)
+    assert_success auth_response
+    assert '33333 ', auth_response.params['authCode']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_success reversal_response
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
+  end
+
+  def test35
+    credit_card = CreditCard.new(number: '375001000000005', month: '01',
+                                 year: '2021', brand: 'american_express')
+
+    options = {
+      order_id: '35',
+      billing_address: {
+        name: 'Bob Black',
+        address1: '4 Main St.',
+        city: 'Laurel',
+        state: 'MD',
+        zip: '20708',
+        country: 'US'
+      }
+    }
+
+    assert auth_response = @gateway.authorize(10100, credit_card, options)
+    assert_success auth_response
+    assert_equal '44444 ', auth_response.params['authCode']
+    assert_equal 'A', auth_response.avs_result['code']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert capture_response = @gateway.capture(5050, auth_response.authorization, options)
+    assert_success capture_response
+    puts "Test #{options[:order_id]}A: #{txn_id(capture_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Reversal amount does not match Authorization amount', reversal_response.message
+    puts "Test #{options[:order_id]}B: #{txn_id(reversal_response)}"
+  end
+
+  def test36
+    credit_card = CreditCard.new(number: '375000026600004', month: '01',
+                                 year: '2021', brand: 'american_express')
+
+    options = {
+      order_id: '36'
+    }
+
+    assert auth_response = @gateway.authorize(20500, credit_card, options)
+    assert_success auth_response
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+
+    assert reversal_response = @gateway.void(auth_response.authorization, options)
+    assert_failure reversal_response
+    assert 'Reversal amount does not match Authorization amount', reversal_response.message
+    puts "Test #{options[:order_id]}A: #{txn_id(reversal_response)}"
+  end
+
+  # Echeck
+  def test37
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '37',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3001, check, options)
+    assert_failure auth_response
+    assert_equal 'Invalid Account Number', auth_response.message
+    assert_equal '301', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test38
+    check = check(
+      name: 'John Smith',
+      routing_number:  '011075150',
+      account_number: '1099999999',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '38',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3002, check, options)
+    assert_success auth_response
+    assert_equal 'Approved', auth_response.message
+    assert_equal '000', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test39
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '053100300',
+      account_number: '3099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '39',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Good Goods Inc',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3003, check, options)
+    assert_failure auth_response
+    assert_equal 'Decline - Negative Information on File', auth_response.message
+    assert_equal '950', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test40
+    declined_authorize_check = check(
+      name: 'Peter Green',
+      routing_number: '011075150',
+      account_number: '8099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '40',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert auth_response = @gateway.authorize(3004, declined_authorize_check, options)
+    assert_failure auth_response
+    assert_equal 'Absolute Decline', auth_response.message
+    assert_equal '951', auth_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(auth_response)}"
+  end
+
+  def test41
+    check = check(
+      name: 'Mike Hammer',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '41',
+      billing_address: {
+        name: 'Mike Hammer',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2008, check, options)
+    assert_failure purchase_response
+    assert_equal 'Invalid Account Number', purchase_response.message
+    assert_equal '301', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test42
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '42',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2004, check, options)
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+    assert_equal '000', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test43
+    check = check(
+      name: 'Peter Green',
+      routing_number:  '011075150',
+      account_number: '6099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '43',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2007, check, options)
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+    assert_equal '000', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test44
+    check = check(
+      name: 'Peter Green',
+      routing_number: '053133052',
+      account_number: '9099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '44',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2009, check, options)
+    assert_failure purchase_response
+    assert_equal 'Invalid Bank Routing Number', purchase_response.message
+    assert_equal '900', purchase_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(purchase_response)}"
+  end
+
+  def test45
+    check = check(
+      name: 'John Smith',
+      routing_number:  '053100300',
+      account_number: '10@BC99999',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '45',
+      billing_address: {
+        name: 'John Smith',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert refund_response = @gateway.refund(1001, check, options)
+    assert_failure refund_response
+    assert_equal 'Invalid Account Number', refund_response.message
+    assert_equal '301', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test46
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '011075150',
+      account_number: '3099999999',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '46',
+      order_source: 'telephone',
+      billing_address: {
+        name: 'Robert Jones',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444',
+        company: 'Widget Inc'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1003, check, options)
+    sleep(10)
+    assert refund_response = @gateway.refund(1003, purchase_response.authorization, options)
+    assert_success refund_response
+    assert_equal 'Approved', refund_response.message
+    assert_equal '000', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test47
+    check = check(
+      name: 'Peter Green',
+      routing_number:  '211370545',
+      account_number: '6099999993',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '47',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1007, check, options)
+    assert refund_response = @gateway.refund(1007, purchase_response.authorization, options)
+    assert_success refund_response
+    assert_equal 'Approved', refund_response.message
+    assert_equal '000', refund_response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(refund_response)}"
+  end
+
+  def test48
+    check = check(
+      name: 'Peter Green',
+      routing_number: '011075150',
+      account_number: '6099999992',
+      account_type: 'Corporate'
+    )
+    options = {
+      order_id: '43',
+      billing_address: {
+        name: 'Peter Green',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        company: 'Green Co',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2007, check, options)
+    assert_success purchase_response
+    assert refund_response = @gateway.refund(2007, purchase_response.authorization, options)
+    assert_equal '000', refund_response.params['response']
+    puts "Test 48: #{txn_id(refund_response)}"
+  end
+
+  def test49
+    assert refund_response = @gateway.refund(2007, 2)
+    assert_failure refund_response
+    assert_equal '360', refund_response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', refund_response.message
+    puts "Test 49: #{txn_id(refund_response)}"
+  end
+
+  def test_echeck_void1
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '42',
+      id: '236222',
+      billing_address: {
+        name: 'Tom Black',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(2004, check, options)
+    assert_success purchase_response
+    sleep(10)
+    assert void_response = @gateway.void(purchase_response.authorization)
+    assert_equal '000', void_response.params['response']
+    puts "Test void1: #{txn_id(void_response)}"
+  end
+
+  def test_echeck_void2
+    check = check(
+      name: 'Robert Jones',
+      routing_number:  '011075150',
+      account_number: '3099999999',
+      account_type: 'Checking'
+    )
+    options = {
+      order_id: '46',
+      id: '232222',
+      billing_address: {
+        name: 'Robert Jones',
+        address1: '8 Main St.',
+        city: 'Manchester',
+        state: 'NH',
+        zip: '03101',
+        country: 'US',
+        email: 'test@test.com',
+        phone: '2233334444'
+      }
+    }
+    assert purchase_response = @gateway.purchase(1003, check, options)
+    assert_success purchase_response
+    sleep(20)
+    assert void_response = @gateway.void(purchase_response.authorization)
+    assert_equal '000', void_response.params['response']
+    puts "Test void2: #{txn_id(void_response)}"
+  end
+
+  def test_echeck_void3
+    assert void_response = @gateway.void(2)
+    assert_failure void_response
+    assert_equal '360', void_response.params['response']
+    assert_equal 'No transaction found with specified transaction Id', void_response.message
+    puts "Test void3: #{txn_id(void_response)}"
+  end
+
+  # Explicit Token Registration Tests
+  def test50
+    credit_card = CreditCard.new(number: '4457119922390123')
+    options     = {
+      order_id: '50'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_success store_response
+    assert_equal '445711', store_response.params['bin']
+    assert_equal 'VI', store_response.params['type']
+    assert_equal '0123', store_response.params['litleToken'][-4, 4]
+    assert_equal '801', store_response.params['response']
+    assert_equal 'Account number was successfully registered', store_response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test51
+    credit_card = CreditCard.new(number: '4457119999999999')
+    options = {
+      order_id: '51'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_failure store_response
+    assert_equal 'Credit card number was invalid', store_response.message
+    assert_equal '820', store_response.params['response']
+    assert_equal nil, store_response.params['litleToken']
+  end
+
+  def test52
+    credit_card = CreditCard.new(number: '4457119922390123')
+    options = {
+      order_id: '52'
+    }
+
+    # store
+    store_response = @gateway.store(credit_card, options)
+
+    assert_success store_response
+    assert_equal 'Account number was previously registered', store_response.message
+    assert_equal '445711', store_response.params['bin']
+    assert_equal 'VI', store_response.params['type']
+    assert_equal '802', store_response.params['response']
+    assert_equal '0123', store_response.params['litleToken'][-4, 4]
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
+  end
+
+  def test53
+    check = check(
+      routing_number: '011100012',
+      account_number: '1099999998'
+    )
+    options = {
+      order_id: '53'
+    }
+
+    store_response = @gateway.store(check, options)
+
+    assert_success store_response
+    assert_equal '998', store_response.params['eCheckAccountSuffix']
+    assert_equal 'EC', store_response.params['type']
+    assert_equal '801', store_response.params['response']
+    assert_equal 'Account number was successfully registered', store_response.message
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
+  end
+
+  def test54
+    check = check(
+      routing_number: '1145_7895',
+      account_number: '1022222102'
+    )
+    options = {
+      order_id: '54'
+    }
+
+    store_response = @gateway.store(check, options)
+
+    assert_failure store_response
+    assert_equal '900', store_response.params['response']
+    assert_equal 'Invalid Bank Routing Number', store_response.message
+    puts "Test #{options[:order_id]}: #{txn_id(store_response)}"
+  end
+
+  # Implicit Token Registration Tests
+  def test55
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
+    options = {
+      order_id: '55'
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, credit_card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal '0196', response.params['tokenResponse_litleToken'][-4, 4]
+    assert %w(801 802).include? response.params['tokenResponse_tokenResponseCode']
+    assert_equal 'MC', response.params['tokenResponse_type']
+    assert_equal '543510', response.params['tokenResponse_bin']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test56
+    credit_card = CreditCard.new(number: '5435109999999999',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
+    options = {
+      order_id: '56'
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, credit_card, options)
+
+    assert_failure response
+    assert_equal '301', response.params['response']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test57_58
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
+    options = {
+      order_id: '57'
+    }
+
+    # authorize card
+    assert response = @gateway.authorize(15000, credit_card, options)
+
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal '0196', response.params['tokenResponse_litleToken'][-4, 4]
+    assert %w(801 802).include? response.params['tokenResponse_tokenResponseCode']
+    assert_equal 'MC', response.params['tokenResponse_type']
+    assert_equal '543510', response.params['tokenResponse_bin']
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+
+    # authorize token
+    token   = response.params['tokenResponse_litleToken']
+    options = {
+      order_id: '58',
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
+      }
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, token, options)
+
+    assert_success response
+    assert_equal 'Approved', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test59
+    token   = '1111000100092332'
+    options = {
+      order_id: '59',
+      token: {
+        month: '11',
+        year: '2021'
+      }
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, token, options)
+
+    assert_failure response
+    assert_equal '822', response.params['response']
+    assert_equal 'Token was not found', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test60
+    token   = '171299999999999'
+    options = {
+      order_id: '60',
+      token: {
+        month: '11',
+        year: '2014'
+      }
+    }
+
+    # authorize
+    assert response = @gateway.authorize(15000, token, options)
+
+    assert_failure response
+    assert_equal '823', response.params['response']
+    assert_equal 'Token was invalid', response.message
+    puts "Test #{options[:order_id]}: #{txn_id(response)}"
+  end
+
+  def test_apple_pay_purchase
+    options = {
+      order_id: transaction_id
+    }
+    decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        month: '01',
+        year: '2021',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+
+    assert response = @gateway.purchase(10010, decrypted_apple_pay, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_android_pay_purchase
+    options = {
+      order_id: transaction_id
+    }
+    decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2021',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+
+    assert response = @gateway.purchase(10010, decrypted_android_pay, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_three_d_secure
+    three_d_secure_assertions('3DS1', '4100200300000004', 'visa', '3dsAuthenticated', '0')
+    three_d_secure_assertions('3DS2', '4100200300000012', 'visa', '3dsAuthenticated', '1')
+    three_d_secure_assertions('3DS3', '4100200300000103', 'visa', '3dsAuthenticated', '2')
+    three_d_secure_assertions('3DS4', '4100200300001002', 'visa', '3dsAuthenticated', 'A')
+    three_d_secure_assertions('3DS5', '4100200300000020', 'visa', '3dsAuthenticated', '3')
+    three_d_secure_assertions('3DS6', '4100200300000038', 'visa', '3dsAuthenticated', '4')
+    three_d_secure_assertions('3DS7', '4100200300000046', 'visa', '3dsAuthenticated', '5')
+    three_d_secure_assertions('3DS8', '4100200300000053', 'visa', '3dsAuthenticated', '6')
+    three_d_secure_assertions('3DS9', '4100200300000061', 'visa', '3dsAuthenticated', '7')
+    three_d_secure_assertions('3DS10', '4100200300000079', 'visa', '3dsAuthenticated', '8')
+    three_d_secure_assertions('3DS11', '4100200300000087', 'visa', '3dsAuthenticated', '9')
+    three_d_secure_assertions('3DS12', '4100200300000095', 'visa', '3dsAuthenticated', 'B')
+    three_d_secure_assertions('3DS13', '4100200300000111', 'visa', '3dsAuthenticated', 'C')
+    three_d_secure_assertions('3DS14', '4100200300000129', 'visa', '3dsAuthenticated', 'D')
+    three_d_secure_assertions('3DS15', '5112010200000001', 'master', '3dsAttempted', nil)
+    three_d_secure_assertions('3DS16', '5112010200000001', 'master', '3dsAttempted', nil)
+  end
+
+  def test_authorize_and_purchase_and_credit_with_token
+    options = {
+      order_id: transaction_id,
+      billing_address: {
+        name: 'John Smith',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        zip: '01803-3747',
+        country: 'US'
+      }
+    }
+
+    credit_card = CreditCard.new(number: '5435101234510196',
+                                 month: '11',
+                                 year: '2014',
+                                 brand: 'master',
+                                 verification_value: '987')
+
+    # authorize
+    assert auth_response = @gateway.authorize(0, credit_card, options)
+
+    assert_success auth_response
+    assert_equal 'Approved', auth_response.message
+    token = auth_response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['litleToken']
+    assert_equal '0196', token[-4, 4]
+    assert %w(801 802).include? auth_response.params['litleOnlineResponse']['authorizationResponse']['tokenResponse']['tokenResponseCode']
+
+    # purchase
+    purchase_options = options.merge({
+      order_id: transaction_id,
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
+      }
+    })
+
+    assert purchase_response = @gateway.purchase(100, token, purchase_options)
+    assert_success purchase_response
+    assert_equal 'Approved', purchase_response.message
+    assert_equal purchase_options[:order_id], purchase_response.params['litleOnlineResponse']['saleResponse']['id']
+
+    # credit
+    credit_options = options.merge({
+      order_id: transaction_id,
+      token: {
+        month: credit_card.month,
+        year: credit_card.year
+      }
+    })
+
+    assert credit_response = @gateway.credit(500, token, credit_options)
+    assert_success credit_response
+    assert_equal 'Approved', credit_response.message
+    assert_equal credit_options[:order_id], credit_response.params['litleOnlineResponse']['creditResponse']['id']
+  end
+
+  private
+
+  def auth_assertions(amount, card, options, assertions = {})
+    # 1: authorize
+    assert response = @gateway.authorize(amount, card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result['code'] if assertions[:avs]
+    assert_equal assertions[:cvv], response.cvv_result['code'] if assertions[:cvv]
+    assert_equal auth_code(options[:order_id]), response.params['authCode']
+
+    # 1A: capture
+    assert response = @gateway.capture(amount, response.authorization, { id: transaction_id })
+    assert_equal 'Approved', response.message
+
+    # 1B: credit
+    assert response = @gateway.credit(amount, response.authorization, { id: transaction_id })
+    assert_equal 'Approved', response.message
+
+    # 1C: void
+    assert response = @gateway.void(response.authorization, { id: transaction_id })
+    assert_equal 'Approved', response.message
+  end
+
+  def authorize_avs_assertions(credit_card, options, assertions = {})
+    assert response = @gateway.authorize(000, credit_card, options)
+    assert_equal assertions.key?(:success) ? assertions[:success] : true, response.success?
+    assert_equal assertions[:message] || 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result['code'], caller.inspect
+    assert_equal assertions[:cvv], response.cvv_result['code'], caller.inspect if assertions[:cvv]
+  end
+
+  def sale_assertions(amount, card, options, assertions = {})
+    # 1: sale
+    assert response = @gateway.purchase(amount, card, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_equal assertions[:avs], response.avs_result['code'] if assertions[:avs]
+    assert_equal assertions[:cvv], response.cvv_result['code'] if assertions[:cvv]
+    # assert_equal auth_code(options[:order_id]), response.params['authCode']
+
+    # 1B: credit
+    assert response = @gateway.credit(amount, response.authorization, { id: transaction_id })
+    assert_equal 'Approved', response.message
+
+    # 1C: void
+    assert response = @gateway.void(response.authorization, { id: transaction_id })
+    assert_equal 'Approved', response.message
+  end
+
+  def three_d_secure_assertions(test_id, card, type, source, result)
+    credit_card = CreditCard.new(number: card, month: '01',
+                                 year: '2021', brand: type,
+                                 verification_value: '261',
+                                 name: 'Mike J. Hammer')
+
+    options = {
+      order_id: test_id,
+      order_source: source,
+      cavv: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+    }
+
+    assert response = @gateway.authorize(10100, credit_card, options)
+    assert_success response
+    assert_equal result, response.params['fraudResult_authenticationResult']
+    puts "Test #{test_id}: #{txn_id(response)}"
+  end
+
+  def transaction_id
+    # A unique identifier assigned by the presenter and mirrored back in the response.
+    # This attribute is also used for Duplicate Transaction Detection.
+    # For Online transactions, omitting this attribute, or setting it to a
+    # null value (id=""), disables Duplicate Detection for the transaction.
+    #
+    # minLength = N/A   maxLength = 25
+    generate_unique_id[0, 24]
+  end
+
+  def auth_code(order_id)
+    order_id * 5 + ' '
+  end
+
+  def txn_id(response)
+    response.authorization.split(';')[0]
+  end
+end

--- a/test/remote/gateways/remote_litle_new_test.rb
+++ b/test/remote/gateways/remote_litle_new_test.rb
@@ -1,0 +1,741 @@
+require 'test_helper'
+
+class RemoteLitleNewTest < Test::Unit::TestCase
+  def setup
+    @gateway = LitleNewGateway.new(fixtures(:litle_new))
+    @credit_card_hash = {
+      first_name: 'John',
+      last_name: 'Smith',
+      month: '01',
+      year: '2024',
+      brand: 'visa',
+      number: '4242424242424242',
+      verification_value: '111'
+    }
+
+    @options = {
+      order_id: '1',
+      email: 'wow@example.com',
+      billing_address: {
+        company: 'testCompany',
+        address1: '1 Main St.',
+        city: 'Burlington',
+        state: 'MA',
+        country: 'USA',
+        zip: '01803-3747',
+        phone: '1234567890'
+      }
+    }
+    @credit_card1 = CreditCard.new(@credit_card_hash)
+
+    @credit_card2 = CreditCard.new(
+      first_name: 'Joe',
+      last_name: 'Green',
+      month: '06',
+      year: '2030',
+      brand: 'visa',
+      number: '4457010100000008',
+      verification_value: '992'
+    )
+    @credit_card_nsf = CreditCard.new(
+      first_name: 'Joe',
+      last_name: 'Green',
+      month: '06',
+      year: '2030',
+      brand: 'visa',
+      number: '4488282659650110',
+      verification_value: '992'
+    )
+    @decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        month: '01',
+        year: '2030',
+        brand: 'visa',
+        number:  '44444444400009',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+    @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2030',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+    @check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'checking'
+    )
+    @authorize_check = check(
+      name: 'John Smith',
+      routing_number: '011075150',
+      account_number: '1099999999',
+      account_type: 'checking'
+    )
+    @store_check = check(
+      routing_number: '011100012',
+      account_number: '1099999998'
+    )
+  end
+
+  def test_successful_authorization
+    assert response = @gateway.authorize(10010, @credit_card1, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_authorization_with_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    assert @gateway.authorize(10010, @credit_card1, options)
+  end
+
+  def test_successful_authorization_with_echeck
+    options = @options.merge({
+      order_id: '38',
+      order_source: 'telephone'
+    })
+    assert response = @gateway.authorize(3002, @authorize_check, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_avs_and_cvv_result
+    omit "on test sandbox not working"
+    assert response = @gateway.authorize(1000, @credit_card1, @options)
+    assert_equal 'X', response.avs_result['code']
+    assert_equal 'M', response.cvv_result['code']
+  end
+
+  def test_unsuccessful_authorization
+    omit 'test sandbox accept all'
+    assert response = @gateway.authorize(10010, @credit_card2,
+      {
+        order_id: '6',
+        billing_address: {
+          name: 'Joe Green',
+          address1: '6 Main St.',
+          city: 'Derry',
+          state: 'NH',
+          zip: '03038',
+          country: 'US'
+        }
+      })
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+  end
+
+  def test_successful_purchase
+    assert response = @gateway.purchase(10010, @credit_card1, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_some_empty_address_parts
+    assert response = @gateway.purchase(10010, @credit_card1, {
+      order_id: '1',
+      email: 'wow@example.com',
+      billing_address: {
+      }
+    })
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_debt_repayment_flag
+    assert response = @gateway.purchase(10010, @credit_card1, @options.merge(debt_repayment: true))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_3ds_fields
+    options = @options.merge({
+      order_source: '3dsAuthenticated',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      cavv: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+    })
+    assert response = @gateway.purchase(10010, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_apple_pay
+    assert response = @gateway.purchase(1000, @decrypted_apple_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_android_pay
+    assert response = @gateway.purchase(10000, @decrypted_android_pay)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    assert response = @gateway.purchase(10010, @credit_card1, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_purchase_with_echeck
+    options = @options.merge({
+      order_id: '42',
+      order_source: 'telephone'
+    })
+    assert response = @gateway.purchase(2004, @check, options)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_purchase
+    omit 'sandbox accept all cards'
+    assert response = @gateway.purchase(10010, @credit_card2, {
+      order_id: '6',
+      billing_address: {
+        name: 'Joe Green',
+        address1: '6 Main St.',
+        city: 'Derry',
+        state: 'NH',
+        zip: '03038',
+        country: 'US'
+      }
+    })
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+  end
+
+  def test_authorize_capture_refund_void
+    assert auth = @gateway.authorize(1000, @credit_card1, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+
+    assert refund = @gateway.refund(nil, capture.authorization)
+    assert_success refund
+    assert_equal 'Approved', refund.message
+
+    assert void = @gateway.void(refund.authorization)
+    assert_success void
+    assert_equal 'Approved', void.message
+  end
+
+  def test_authorize_and_capture_with_stored_credential_recurring
+    credit_card = CreditCard.new(@credit_card_hash.merge(
+                                   number: '4242424242424242',
+                                   month: '05',
+                                   year: '2030',
+                                   verification_value: '463'
+                                 ))
+
+    initial_options = @options.merge(
+      order_id: 'Net_Id1',
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+    assert auth = @gateway.authorize(4999, credit_card, initial_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert network_transaction_id = auth.params['networkTransactionId']
+
+    assert capture = @gateway.capture(4999, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+
+    used_options = @options.merge(
+      order_id: 'Net_Id1a',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    assert auth = @gateway.authorize(4999, credit_card, used_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(4999, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_authorize_and_capture_with_stored_credential_installment
+    credit_card = CreditCard.new(@credit_card_hash.merge(
+                                   number: '4457010000000009',
+                                   month: '01',
+                                   year: '2030',
+                                   verification_value: '111'
+                                 ))
+
+    initial_options = @options.merge(
+      order_id: 'Net_Id2',
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+    assert auth = @gateway.authorize(5500, credit_card, initial_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert network_transaction_id = auth.params['networkTransactionId']
+
+    assert capture = @gateway.capture(5500, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+
+    used_options = @options.merge(
+      order_id: 'Net_Id2a',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    assert auth = @gateway.authorize(5500, credit_card, used_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(5500, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_authorize_and_capture_with_stored_credential_mit_card_on_file
+    credit_card = CreditCard.new(@credit_card_hash.merge(
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2030',
+                                   verification_value: '111'
+                                 ))
+
+    initial_options = @options.merge(
+      order_id: 'Net_Id3',
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+    assert auth = @gateway.authorize(5500, credit_card, initial_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert network_transaction_id = auth.params['networkTransactionId']
+
+    assert capture = @gateway.capture(5500, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+
+    used_options = @options.merge(
+      order_id: 'Net_Id3a',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    assert auth = @gateway.authorize(2500, credit_card, used_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(2500, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_authorize_and_capture_with_stored_credential_cit_card_on_file
+    credit_card = CreditCard.new(@credit_card_hash.merge(
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2030',
+                                   verification_value: '111'
+                                 ))
+
+    initial_options = @options.merge(
+      order_id: 'Net_Id3',
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: nil
+      }
+    )
+    assert auth = @gateway.authorize(5500, credit_card, initial_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert network_transaction_id = auth.params['networkTransactionId']
+
+    assert capture = @gateway.capture(5500, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+
+    used_options = @options.merge(
+      order_id: 'Net_Id3b',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    assert auth = @gateway.authorize(4000, credit_card, used_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(4000, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_purchase_with_stored_credential_cit_card_on_file_non_ecommerce
+    credit_card = CreditCard.new(@credit_card_hash.merge(
+                                   number: '4457000800000002',
+                                   month: '01',
+                                   year: '2030',
+                                   verification_value: '111'
+                                 ))
+
+    initial_options = @options.merge(
+      order_id: 'Net_Id3',
+      order_source: '3dsAuthenticated',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      cavv: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: nil
+      }
+    )
+    assert auth = @gateway.purchase(5500, credit_card, initial_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+    assert network_transaction_id = auth.params['networkTransactionId']
+
+    used_options = @options.merge(
+      order_id: 'Net_Id3b',
+      order_source: '3dsAuthenticated',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      cavv: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: network_transaction_id
+      }
+    )
+    assert auth = @gateway.purchase(4000, credit_card, used_options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+  end
+
+  def test_void_with_echeck
+    options = @options.merge({
+      order_id: '42',
+      order_source: 'telephone'
+    })
+    assert sale = @gateway.purchase(2004, @check, options)
+
+    assert void = @gateway.void(sale.authorization)
+    assert_success void
+    assert_equal 'Approved', void.message
+  end
+
+  def test_void_authorization
+    assert auth = @gateway.authorize(10010, @credit_card1, @options)
+
+    assert void = @gateway.void(auth.authorization)
+    assert_success void
+    assert_equal 'Approved', void.message
+  end
+
+  def test_unsuccessful_void
+    omit 'test sandbox accept all Transaction Id'
+    assert void = @gateway.void('123456789012345360;authorization;100')
+    assert_failure void
+    assert_equal 'No transaction found with specified Transaction Id', void.message
+  end
+
+  def test_successful_credit
+    assert credit = @gateway.credit(123456, @credit_card1, @options)
+    assert_success credit
+    assert_equal 'Approved', credit.message
+  end
+
+  def test_failed_credit
+    @credit_card1.number = '1234567890'
+    assert credit = @gateway.credit(1, @credit_card1, @options)
+    assert_failure credit
+  end
+
+  def test_partial_refund
+    assert purchase = @gateway.purchase(10010, @credit_card1, @options)
+
+    assert refund = @gateway.refund(444, purchase.authorization)
+    assert_success refund
+    assert_equal 'Approved', refund.message
+  end
+
+  def test_partial_refund_with_echeck
+    options = @options.merge({
+      order_id: '82',
+      order_source: 'telephone'
+    })
+    assert purchase = @gateway.purchase(2004, @check, options)
+
+    assert refund = @gateway.refund(444, purchase.authorization)
+    assert_success refund
+    assert_equal 'Approved', refund.message
+  end
+
+  def test_partial_capture
+    assert auth = @gateway.authorize(10010, @credit_card1, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(5005, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_full_amount_capture
+    assert auth = @gateway.authorize(10010, @credit_card1, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(10010, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_nil_amount_capture
+    assert auth = @gateway.authorize(10010, @credit_card1, @options)
+    assert_success auth
+    assert_equal 'Approved', auth.message
+
+    assert capture = @gateway.capture(nil, auth.authorization)
+    assert_success capture
+    assert_equal 'Approved', capture.message
+  end
+
+  def test_capture_unsuccessful
+    omit 'sandbox accept each Transaction Id'
+    assert capture_response = @gateway.capture(10010, '123456789012345360')
+    assert_failure capture_response
+    assert_equal 'No transaction found with specified Transaction Id', capture_response.message
+  end
+
+  def test_refund_unsuccessful
+    omit 'sandbox accept each Transaction Id'
+    assert credit_response = @gateway.refund(10010, '123456789012345360')
+    assert_failure credit_response
+    assert_equal 'No transaction found with specified Transaction Id', credit_response.message
+  end
+
+  def test_void_unsuccessful
+    assert void_response = @gateway.void('123456789012345360')
+    assert_failure void_response
+    assert_equal 'No transaction found with specified Transaction Id', void_response.message
+  end
+
+  def test_store_successful
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4242424242424242'))
+    assert store_response = @gateway.store(credit_card, order_id: '50')
+
+    assert_success store_response
+    assert_equal 'Account number was successfully registered', store_response.message
+    assert_equal '801', store_response.params['response']
+    assert_equal '1111222233334444', store_response.params['litleToken']
+  end
+
+  def test_store_with_paypage_registration_id_successful
+    paypage_registration_id = 'cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg='
+    assert store_response = @gateway.store(paypage_registration_id, order_id: '50')
+
+    assert_success store_response
+    assert_equal 'Account number was successfully registered', store_response.message
+    assert_equal '801', store_response.params['response']
+    assert_equal '1111222233334444', store_response.params['litleToken']
+  end
+
+  def test_store_unsuccessful
+    omit 'test sandbox accept all numbers'
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '0000000000000000'))
+    assert store_response = @gateway.store(credit_card, order_id: '51')
+
+    assert_failure store_response
+    assert_equal 'Credit card number was invalid', store_response.message
+    assert_equal '820', store_response.params['response']
+  end
+
+  def test_store_and_purchase_with_token_successful
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '4242424242424242'))
+    assert store_response = @gateway.store(credit_card)
+    assert_success store_response
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(1000, token, order_id: 'grs-2021020114113394')
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_purchase_with_token_and_date_successful
+    assert store_response = @gateway.store(@credit_card1, order_id: '50')
+    assert_success store_response
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(1000, token, { basis_expiration_month: '01', basis_expiration_year: '2024' })
+
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_echeck_store_and_purchase
+    omit 'we do not use echeck'
+    assert store_response = @gateway.store(@store_check)
+    assert_success store_response
+    assert_equal 'Account number was successfully registered', store_response.message
+
+    token = store_response.authorization
+    assert_equal store_response.params['litleToken'], token
+
+    assert response = @gateway.purchase(10010, token)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_successful_verify
+    assert response = @gateway.verify(@credit_card1, @options)
+    assert_success response
+    assert_equal 'Approved', response.message
+    assert_success response.responses.last, 'The void should succeed'
+  end
+
+  def test_unsuccessful_verify
+    assert response = @gateway.verify(@credit_card_nsf, @options)
+    assert_failure response
+    assert_match %r{Insufficient Funds}, response.message
+  end
+
+  def test_successful_purchase_with_dynamic_descriptors
+    assert response = @gateway.purchase(10010, @credit_card1, @options.merge(
+                                                                descriptor_name: 'SuperCompany',
+                                                                descriptor_phone: '9193341121'
+                                                              ))
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_xml_schema_validation
+    credit_card = CreditCard.new(@credit_card_hash.merge(number: '123456'))
+    assert store_response = @gateway.store(credit_card, order_id: '51')
+
+    assert_failure store_response
+    assert_match(/^Error validating xml data against the schema/, store_response.message)
+    assert_equal '1', store_response.params['response']
+  end
+
+  def test_purchase_scrubbing_with_password
+    gateway = LitleNewGateway.new({
+      login: nil,
+      password: "MERCHANT",
+      merchant_id: 101,
+    })
+    credit_card = CreditCard.new(@credit_card_hash.merge(verification_value: '999'))
+    transcript = capture_transcript(gateway) do
+      gateway.purchase(10010, credit_card, @options)
+    end
+    transcript = gateway.scrub(transcript)
+
+    assert_scrubbed(credit_card.number, transcript)
+    assert_scrubbed(credit_card.verification_value, transcript)
+    assert_scrubbed(gateway.options[:password], transcript)
+  end
+
+  def test_purchase_scrubbing_with_login
+    gateway = LitleNewGateway.new({
+      login: "ACTIVE",
+      password: nil,
+      merchant_id: 101,
+    })
+    credit_card = CreditCard.new(@credit_card_hash.merge(verification_value: '999'))
+    transcript = capture_transcript(gateway) do
+      gateway.purchase(10010, credit_card, @options)
+    end
+    transcript = gateway.scrub(transcript)
+
+    assert_scrubbed(credit_card.number, transcript)
+    assert_scrubbed(credit_card.verification_value, transcript)
+    assert_scrubbed(gateway.options[:login], transcript)
+  end
+
+  def test_echeck_scrubbing_with_password
+    gateway = LitleNewGateway.new({
+      login: nil,
+      password: "MERCHANT",
+      merchant_id: 101,
+    })
+
+    options = @options.merge({
+      order_id: '42',
+      order_source: 'telephone'
+    })
+    transcript = capture_transcript(gateway) do
+      gateway.purchase(2004, @check, options)
+    end
+    transcript = gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, transcript)
+    assert_scrubbed(@check.routing_number, transcript)
+    assert_scrubbed(gateway.options[:password], transcript)
+  end
+
+  def test_echeck_scrubbing_with_login
+    gateway = LitleNewGateway.new({
+      login: "ACTIVE",
+      password: nil,
+      merchant_id: 101,
+    })
+
+    options = @options.merge({
+      order_id: '42',
+      order_source: 'telephone'
+    })
+    transcript = capture_transcript(gateway) do
+      gateway.purchase(2004, @check, options)
+    end
+    transcript = gateway.scrub(transcript)
+
+    assert_scrubbed(@check.account_number, transcript)
+    assert_scrubbed(@check.routing_number, transcript)
+    assert_scrubbed(gateway.options[:login], transcript)
+  end
+end

--- a/test/unit/gateways/litle_new_test.rb
+++ b/test/unit/gateways/litle_new_test.rb
@@ -1,0 +1,1026 @@
+require 'test_helper'
+
+class LitleTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    Base.mode = :test
+
+    @gateway = LitleGateway.new(
+      login: 'login',
+      password: 'password',
+      merchant_id: 'merchant_id'
+    )
+
+    @credit_card = credit_card
+    @decrypted_apple_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        month: '01',
+        year: '2012',
+        brand: 'visa',
+        number:  '44444444400009',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+    @decrypted_android_pay = ActiveMerchant::Billing::NetworkTokenizationCreditCard.new(
+      {
+        source: :android_pay,
+        month: '01',
+        year: '2021',
+        brand: 'visa',
+        number:  '4457000300000007',
+        payment_cryptogram: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA='
+      }
+    )
+    @amount = 100
+    @options = {}
+    @check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      account_type: 'checking'
+    )
+    @authorize_check = check(
+      name: 'John Smith',
+      routing_number: '011075150',
+      account_number: '1099999999',
+      account_type: 'checking'
+    )
+  end
+
+  def test_successful_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal "100000000000000006;sale;100", response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_test_site
+    gateway = LitleGateway.new(
+      login: '',
+      password: '',
+      merchant_id: 'merchant_id'
+    )
+    response = stub_comms do
+      gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, _data, _headers|
+      # Counterpoint to test_successful_postlive_url:
+      assert_match(/www\.testvantivcnp\.com/, endpoint)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+    assert response.test?
+  end
+
+  def test_successful_postlive_url
+    @gateway = LitleGateway.new(
+      login: 'login',
+      password: 'password',
+      merchant_id: 'merchant_id',
+      url_override: 'postlive'
+    )
+
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |endpoint, _data, _headers|
+      assert_match(/payments\.vantivprelive\.com/, endpoint)
+    end.respond_with(successful_purchase_response)
+
+    assert_success response
+
+    assert_equal '100000000000000006;sale;100', response.authorization
+    assert response.test?
+  end
+
+  def test_successful_purchase_with_echeck
+    response = stub_comms do
+      @gateway.purchase(2004, @check)
+    end.respond_with(successful_purchase_with_echeck_response)
+
+    assert_success response
+
+    assert_equal '621100411297330000;echeckSales;2004', response.authorization
+    assert response.test?
+  end
+
+  def test_failed_purchase
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(failed_purchase_response)
+
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+    assert_equal '110', response.params['response']
+    assert response.test?
+  end
+
+  def test_passing_merchant_data
+    options = @options.merge(
+      affiliate: 'some-affiliate',
+      campaign: 'super-awesome-campaign',
+      merchant_grouping_id: 'brilliant-group'
+    )
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<affiliate>some-affiliate</affiliate>), data)
+      assert_match(%r(<campaign>super-awesome-campaign</campaign>), data)
+      assert_match(%r(<merchantGroupingId>brilliant-group</merchantGroupingId>), data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_name_on_card
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<billToAddress>\s*<name>Longbob Longsen<), data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_order_id
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_id: '774488')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/774488/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_billing_address
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, billing_address: address)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<billToAddress>.*Widgets.*456.*Apt 1.*Otta.*ON.*K1C.*CA.*555-5/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_shipping_address
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, shipping_address: address)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<shipToAddress>.*Widgets.*456.*Apt 1.*Otta.*ON.*K1C.*CA.*555-5/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_descriptor
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, {
+        descriptor_name: 'Name', descriptor_phone: 'Phone'
+      })
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<customBilling>.*<descriptor>Name<)m, data)
+      assert_match(%r(<customBilling>.*<phone>Phone<)m, data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_passing_debt_repayment
+    stub_comms do
+      @gateway.authorize(@amount, @credit_card, { debt_repayment: true })
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<debtRepayment>true</debtRepayment>), data)
+    end.respond_with(successful_authorize_response)
+  end
+
+  def test_passing_payment_cryptogram
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_apple_pay)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/BwABBJQ1AgAAAAAgJDUCAAAAAAA=/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_passing_basis_date
+    stub_comms do
+      @gateway.purchase(@amount, 'token', { basis_expiration_month: '04', basis_expiration_year: '2027' })
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<expDate>0427<\/expDate>/, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_does_not_pass_empty_checknum
+    check = check(
+      name: 'Tom Black',
+      routing_number:  '011075150',
+      account_number: '4099999992',
+      number: nil,
+      account_type: 'checking'
+    )
+    stub_comms do
+      @gateway.purchase(@amount, check)
+    end.check_request do |_endpoint, data, _headers|
+      assert_not_match(/<checkNum\/>/m, data)
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_add_applepay_order_source
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_apple_pay)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>applepay</orderSource>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_add_android_pay_order_source
+    stub_comms do
+      @gateway.purchase(@amount, @decrypted_android_pay)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>androidpay</orderSource>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_successful_authorize_and_capture
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+
+    assert_equal '100000000000000001;authorization;100', response.authorization
+    assert response.test?
+
+    capture = stub_comms do
+      @gateway.capture(@amount, response.authorization)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/100000000000000001/, data)
+    end.respond_with(successful_capture_response)
+
+    assert_success capture
+  end
+
+  def test_failed_authorize
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(failed_authorize_response)
+
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+    assert_equal '110', response.params['response']
+  end
+
+  def test_failed_capture
+    response = stub_comms do
+      @gateway.capture(@amount, @credit_card)
+    end.respond_with(failed_capture_response)
+
+    assert_failure response
+    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal '360', response.params['response']
+  end
+
+  def test_successful_refund
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(successful_purchase_response)
+
+    assert_equal '100000000000000006;sale;100', response.authorization
+
+    refund = stub_comms do
+      @gateway.refund(@amount, response.authorization)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/100000000000000006/, data)
+    end.respond_with(successful_refund_response)
+
+    assert_success refund
+  end
+
+  def test_failed_refund
+    response = stub_comms do
+      @gateway.refund(@amount, 'SomeAuthorization')
+    end.respond_with(failed_refund_response)
+
+    assert_failure response
+    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal '360', response.params['response']
+  end
+
+  def test_successful_credit
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(successful_credit_response)
+
+    assert_success credit
+    assert_equal 'Approved', credit.message
+  end
+
+  def test_failed_credit
+    credit = stub_comms do
+      @gateway.credit(@amount, @credit_card)
+    end.respond_with(failed_credit_response)
+
+    assert_failure credit
+  end
+
+  def test_successful_void_of_authorization
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card)
+    end.respond_with(successful_authorize_response)
+
+    assert_success response
+    assert_equal '100000000000000001;authorization;100', response.authorization
+
+    void = stub_comms do
+      @gateway.void(response.authorization)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<authReversal.*<litleTxnId>100000000000000001</m, data)
+    end.respond_with(successful_void_of_auth_response)
+
+    assert_success void
+  end
+
+  def test_successful_void_of_other_things
+    refund = stub_comms do
+      @gateway.refund(@amount, 'SomeAuthorization')
+    end.respond_with(successful_refund_response)
+
+    assert_equal '100000000000000003;credit;', refund.authorization
+
+    void = stub_comms do
+      @gateway.void(refund.authorization)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<void.*<litleTxnId>100000000000000003</m, data)
+    end.respond_with(successful_void_of_other_things_response)
+
+    assert_success void
+  end
+
+  def test_failed_void_of_authorization
+    response = stub_comms do
+      @gateway.void('123456789012345360;authorization;100')
+    end.respond_with(failed_void_of_authorization_response)
+
+    assert_failure response
+    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal '360', response.params['response']
+  end
+
+  def test_failed_void_of_other_things
+    response = stub_comms do
+      @gateway.void('123456789012345360;credit;100')
+    end.respond_with(failed_void_of_other_things_response)
+
+    assert_failure response
+    assert_equal 'No transaction found with specified litleTxnId', response.message
+    assert_equal '360', response.params['response']
+  end
+
+  def test_successful_void_of_echeck
+    response = stub_comms do
+      @gateway.void('945032206979933000;echeckSales;2004')
+    end.respond_with(successful_void_of_echeck_response)
+
+    assert_success response
+    assert_equal '986272331806746000;echeckVoid;', response.authorization
+  end
+
+  def test_successful_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/<accountNumber>4242424242424242</, data)
+    end.respond_with(successful_store_response)
+
+    assert_success response
+    assert_equal '1111222233330123', response.authorization
+  end
+
+  def test_successful_store_with_paypage_registration_id
+    response = stub_comms do
+      @gateway.store('cDZJcmd1VjNlYXNaSlRMTGpocVZQY1NNlYE4ZW5UTko4NU9KK3p1L1p1VzE4ZWVPQVlSUHNITG1JN2I0NzlyTg=')
+    end.respond_with(successful_store_paypage_response)
+
+    assert_success response
+    assert_equal '1111222233334444', response.authorization
+  end
+
+  def test_failed_store
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(failed_store_response)
+
+    assert_failure response
+    assert_equal 'Credit card number was invalid', response.message
+    assert_equal '820', response.params['response']
+  end
+
+  def test_successful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card)
+    end.respond_with(successful_authorize_response, successful_void_of_auth_response)
+    assert_success response
+  end
+
+  def test_successful_verify_failed_void
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(successful_authorize_response, failed_void_of_authorization_response)
+    assert_success response
+    assert_equal 'Approved', response.message
+  end
+
+  def test_unsuccessful_verify
+    response = stub_comms do
+      @gateway.verify(@credit_card, @options)
+    end.respond_with(failed_authorize_response, successful_void_of_auth_response)
+    assert_failure response
+    assert_equal 'Insufficient Funds', response.message
+  end
+
+  def test_add_swipe_data_with_creditcard
+    @credit_card.track_data = 'Track Data'
+
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<track>Track Data</track>', data
+      assert_match '<orderSource>retail</orderSource>', data
+      assert_match %r{<pos>.+<\/pos>}m, data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_order_source_with_creditcard_no_track_data
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>ecommerce</orderSource>', data
+      assert %r{<pos>.+<\/pos>}m !~ data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_order_source_override
+    stub_comms do
+      @gateway.purchase(@amount, @credit_card, order_source: 'recurring')
+    end.check_request do |_endpoint, data, _headers|
+      assert_match '<orderSource>recurring</orderSource>', data
+    end.respond_with(successful_purchase_response)
+  end
+
+  def test_unsuccessful_xml_schema_validation
+    response = stub_comms do
+      @gateway.store(@credit_card)
+    end.respond_with(unsuccessful_xml_schema_validation_response)
+
+    assert_failure response
+    assert_match(/^Error validating xml data against the schema/, response.message)
+    assert_equal '1', response.params['response']
+  end
+
+  def test_stored_credential_cit_card_on_file_initial
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: nil
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>initialCOF</processingType>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_cit_card_on_file_used
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: network_transaction_id
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>cardholderInitiatedCOF</processingType>), data)
+      assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
+      assert_match(%r(<orderSource>ecommerce</orderSource>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_cit_cof_doesnt_override_order_source
+    options = @options.merge(
+      order_source: '3dsAuthenticated',
+      xid: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      cavv: 'BwABBJQ1AgAAAAAgJDUCAAAAAAA=',
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'cardholder',
+        network_transaction_id: network_transaction_id
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>cardholderInitiatedCOF</processingType>), data)
+      assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
+      assert_match(%r(<orderSource>3dsAuthenticated</orderSource>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_mit_card_on_file_initial
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>initialCOF</processingType>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_mit_card_on_file_used
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>merchantInitiatedCOF</processingType>), data)
+      assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
+      assert_match(%r(<orderSource>ecommerce</orderSource>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_initial
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>initialInstallment</processingType>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_installment_used
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'installment',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
+      assert_match(%r(<orderSource>installment</orderSource>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_initial
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: true,
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: nil
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<processingType>initialRecurring</processingType>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_stored_credential_recurring_used
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'recurring',
+        initiator: 'merchant',
+        network_transaction_id: network_transaction_id
+      }
+    )
+
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(%r(<originalNetworkTransactionId>#{network_transaction_id}</originalNetworkTransactionId>), data)
+      assert_match(%r(<orderSource>recurring</orderSource>), data)
+    end.respond_with(successful_authorize_stored_credentials)
+
+    assert_success response
+  end
+
+  def test_scrub
+    assert_equal @gateway.scrub(pre_scrub), post_scrub
+  end
+
+  def test_supports_scrubbing?
+    assert @gateway.supports_scrubbing?
+  end
+
+  private
+
+  def network_transaction_id
+    '63225578415568556365452427825'
+  end
+
+  def successful_purchase_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <saleResponse id='1' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000006</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2014-03-31T11:34:39</responseTime>
+          <message>Approved</message>
+          <authCode>11111 </authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+        </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_purchase_with_echeck_response
+    %(
+      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <echeckSalesResponse id='42' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>621100411297330000</litleTxnId>
+          <orderId>42</orderId>
+          <response>000</response>
+          <responseTime>2018-01-09T14:02:20</responseTime>
+          <message>Approved</message>
+        </echeckSalesResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_authorize_stored_credentials
+    %(
+      <litleOnlineResponse xmlns="http://www.litle.com/schema" version="9.14" response="0" message="Valid Format">
+        <authorizationResponse id="1" reportGroup="Default Report Group">
+          <litleTxnId>991939023768015826</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <message>Approved</message>
+          <responseTime>2019-02-26T17:45:29.885</responseTime>
+          <authCode>75045</authCode>
+          <networkTransactionId>63225578415568556365452427825</networkTransactionId>
+        </authorizationResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_purchase_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <saleResponse id='6' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>600000000000000002</litleTxnId>
+          <orderId>6</orderId>
+          <response>110</response>
+          <responseTime>2014-03-31T11:48:47</responseTime>
+          <message>Insufficient Funds</message>
+          <fraudResult>
+            <avsResult>34</avsResult>
+            <cardValidationResult>P</cardValidationResult>
+          </fraudResult>
+        </saleResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_authorize_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <authorizationResponse id='1' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000001</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2014-03-31T12:21:56</responseTime>
+          <message>Approved</message>
+          <authCode>11111 </authCode>
+          <fraudResult>
+            <avsResult>01</avsResult>
+            <cardValidationResult>M</cardValidationResult>
+          </fraudResult>
+        </authorizationResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_authorize_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <authorizationResponse id='6' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>600000000000000001</litleTxnId>
+          <orderId>6</orderId>
+          <response>110</response>
+          <responseTime>2014-03-31T12:24:21</responseTime>
+          <message>Insufficient Funds</message>
+          <fraudResult>
+            <avsResult>34</avsResult>
+            <cardValidationResult>P</cardValidationResult>
+          </fraudResult>
+        </authorizationResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_capture_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <captureResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000002</litleTxnId>
+          <response>000</response>
+          <responseTime>2014-03-31T12:28:07</responseTime>
+          <message>Approved</message>
+        </captureResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_capture_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <captureResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>304546900824606360</litleTxnId>
+          <response>360</response>
+          <responseTime>2014-03-31T12:30:53</responseTime>
+          <message>No transaction found with specified litleTxnId</message>
+        </captureResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_refund_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <creditResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000003</litleTxnId>
+          <response>000</response>
+          <responseTime>2014-03-31T12:36:50</responseTime>
+          <message>Approved</message>
+        </creditResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_refund_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <creditResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>996483567570258360</litleTxnId>
+          <response>360</response>
+          <responseTime>2014-03-31T12:42:41</responseTime>
+          <message>No transaction found with specified litleTxnId</message>
+        </creditResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_credit_response
+    %(
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <litleOnlineResponse version="9.14" response="0" message="Valid Format">
+        <creditResponse id="1" reportGroup="Default Report Group">
+          <litleTxnId>908410935514139173</litleTxnId>
+          <orderId>1</orderId>
+          <response>000</response>
+          <responseTime>2020-10-30T19:19:38.935</responseTime>
+          <message>Approved</message>
+        </creditResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_credit_response
+    %(
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <litleOnlineResponse version="9.14" response="1" message="Error validating xml data against the schema: cvc-minLength-valid: Value '1234567890' with length = '10' is not facet-valid with respect to minLength '13' for type 'ccAccountNumberType'."/>
+    )
+  end
+
+  def successful_void_of_auth_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>972619753208653000</litleTxnId>
+          <orderId>123</orderId>
+          <response>000</response>
+          <responseTime>2014-03-31T12:45:44</responseTime>
+          <message>Approved</message>
+        </authReversalResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_void_of_other_things_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <voidResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>100000000000000004</litleTxnId>
+          <response>000</response>
+          <responseTime>2014-03-31T12:44:52</responseTime>
+          <message>Approved</message>
+        </voidResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_void_of_echeck_response
+    %(
+      <litleOnlineResponse version='9.12' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <echeckVoidResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>986272331806746000</litleTxnId>
+          <response>000</response>
+          <responseTime>2018-01-09T14:20:00</responseTime>
+          <message>Approved</message>
+          <postDate>2018-01-09</postDate>
+        </echeckVoidResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_void_of_authorization_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <authReversalResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>775712323632364360</litleTxnId>
+          <orderId>123</orderId>
+          <response>360</response>
+          <responseTime>2014-03-31T13:03:17</responseTime>
+          <message>No transaction found with specified litleTxnId</message>
+        </authReversalResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_void_of_other_things_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <voidResponse id='' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>486912375928374360</litleTxnId>
+          <response>360</response>
+          <responseTime>2014-03-31T12:55:46</responseTime>
+          <message>No transaction found with specified litleTxnId</message>
+        </voidResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_store_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <registerTokenResponse id='50' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>501000000000000001</litleTxnId>
+          <orderId>50</orderId>
+          <litleToken>1111222233330123</litleToken>
+          <response>801</response>
+          <responseTime>2014-03-31T13:06:41</responseTime>
+          <message>Account number was successfully registered</message>
+          <bin>445711</bin>
+          <type>VI</type>
+        </registerTokenResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def successful_store_paypage_response
+    %(
+      <litleOnlineResponse version='8.2' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <registerTokenResponse id='99999' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>222358384397377801</litleTxnId>
+          <orderId>F12345</orderId>
+          <litleToken>1111222233334444</litleToken>
+          <response>801</response>
+          <responseTime>2015-05-20T14:37:22</responseTime>
+          <message>Account number was successfully registered</message>
+        </registerTokenResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def failed_store_response
+    %(
+      <litleOnlineResponse version='8.22' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>
+        <registerTokenResponse id='51' reportGroup='Default Report Group' customerId=''>
+          <litleTxnId>510000000000000001</litleTxnId>
+          <orderId>51</orderId>
+          <response>820</response>
+          <responseTime>2014-03-31T13:10:51</responseTime>
+          <message>Credit card number was invalid</message>
+        </registerTokenResponse>
+      </litleOnlineResponse>
+    )
+  end
+
+  def unsuccessful_xml_schema_validation_response
+    %(
+    <litleOnlineResponse version='8.29' xmlns='http://www.litle.com/schema'
+                     response='1'
+                     message='Error validating xml data against the schema on line 8\nthe length of the value is 10, but the required minimum is 13.'/>
+
+    )
+  end
+
+  def pre_scrub
+    <<-REQUEST
+      opening connection to www.testlitle.com:443...
+      opened
+      starting SSL for www.testlitle.com:443...
+      SSL established
+      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
+      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>ACTIVE</user>\n    <password>MERCHANT</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>4242424242424242</accountNumber>\n    <cardValidationNum>111</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
+      -> "Server: Apache-Coyote/1.1\r\n"
+      -> "Content-Type: text/xml;charset=utf-8\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      -> "1bf\r\n"
+      reading 447 bytes...
+      -> ""
+      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      read 447 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    REQUEST
+  end
+
+  def post_scrub
+    <<-REQUEST
+      opening connection to www.testlitle.com:443...
+      opened
+      starting SSL for www.testlitle.com:443...
+      SSL established
+      <- "POST /sandbox/communicator/online HTTP/1.1\r\nContent-Type: text/xml\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: www.testlitle.com\r\nContent-Length: 406\r\n\r\n"
+      <- "<litleOnlineRequest xmlns=\"http://www.litle.com/schema\" merchantId=\"101\" version=\"9.4\">\n  <authentication>\n    <user>[FILTERED]</user>\n    <password>[FILTERED]</password>\n  </authentication>\n  <registerTokenRequest reportGroup=\"Default Report Group\">\n    <orderId/>\n    <accountNumber>[FILTERED]</accountNumber>\n    <cardValidationNum>[FILTERED]</cardValidationNum>\n  </registerTokenRequest>\n</litleOnlineRequest>"
+      -> "HTTP/1.1 200 OK\r\n"
+      -> "Date: Mon, 16 May 2016 03:07:36 GMT\r\n"
+      -> "Server: Apache-Coyote/1.1\r\n"
+      -> "Content-Type: text/xml;charset=utf-8\r\n"
+      -> "Connection: close\r\n"
+      -> "Transfer-Encoding: chunked\r\n"
+      -> "\r\n"
+      -> "1bf\r\n"
+      reading 447 bytes...
+      -> ""
+      -> "<litleOnlineResponse version='10.1' response='0' message='Valid Format' xmlns='http://www.litle.com/schema'>\n  <registerTokenResponse id='' reportGroup='Default Report Group' customerId=''>\n    <litleTxnId>185074924759529000</litleTxnId>\n    <litleToken>1111222233334444</litleToken>\n    <response>000</response>\n    <responseTime>2016-05-15T23:07:36</responseTime>\n    <message>Approved</message>\n  </registerTokenResponse>\n</litleOnlineResponse>"
+      read 447 bytes
+      reading 2 bytes...
+      -> ""
+      -> "\r\n"
+      read 2 bytes
+      -> "0\r\n"
+      -> "\r\n"
+      Conn close
+    REQUEST
+  end
+end


### PR DESCRIPTION
This will add Litle New Gateway with support for Stored Credentials.

This new gateway was extracted from this PR: https://github.com/chargify/active_merchant/pull/142

Co-authored-by: Jakub Mikrut <jakub.mikrut@chargify.com>