### PR TITLE
Avoid xml empty tag subsequentAuthTransactionID for cybersource

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -739,10 +739,9 @@ module ActiveMerchant #:nodoc:
         return unless options[:stored_credential]
 
         xml.tag! 'subsequentAuthFirst', 'true' if options.dig(:stored_credential, :initial_transaction)
+        network_transaction_id = options.dig(:stored_credential, :network_transaction_id)
 
-        return if options.dig(:stored_credential, :network_transaction_id).nil?
-
-        xml.tag! 'subsequentAuthTransactionID', options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
+        xml.tag! 'subsequentAuthTransactionID', network_transaction_id if network_transaction_id && options.dig(:stored_credential, :initiator) == 'merchant'
       end
 
       # Where we actually build the full SOAP request using builder

--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -739,6 +739,9 @@ module ActiveMerchant #:nodoc:
         return unless options[:stored_credential]
 
         xml.tag! 'subsequentAuthFirst', 'true' if options.dig(:stored_credential, :initial_transaction)
+
+        return if options.dig(:stored_credential, :network_transaction_id).nil?
+
         xml.tag! 'subsequentAuthTransactionID', options.dig(:stored_credential, :network_transaction_id) if options.dig(:stored_credential, :initiator) == 'merchant'
       end
 

--- a/test/unit/gateways/cyber_source_test.rb
+++ b/test/unit/gateways/cyber_source_test.rb
@@ -531,6 +531,23 @@ class CyberSourceTest < Test::Unit::TestCase
     assert response.test?
   end
 
+  def test_if_empty_tag_is_skipped_for_network_transaction_id
+    @gateway.stubs(:ssl_post).returns(successful_authorization_response)
+
+    @options[:stored_credential] = {
+      :initiator => 'merchant',
+      :reason_type => 'recurring',
+      :initial_transaction => false,
+      :network_transaction_id => nil
+    }
+
+    @gateway.stubs(:ssl_post).with do |host, request_body|
+      assert_not_match %r'<subsequentAuthTransactionID/>', request_body
+    end.returns(successful_purchase_response)
+
+    @gateway.purchase(@amount, @credit_card, @options)
+  end
+
   def test_nonfractional_currency_handling
     @gateway.expects(:ssl_post).with do |host, request_body|
       assert_match %r(<grandTotalAmount>1</grandTotalAmount>), request_body


### PR DESCRIPTION
Why?
https://chargify.atlassian.net/browse/PGT-1078

Some context: basically in case a transaction is made with Visa or MasterCard card and for some reason we don't have a networkTransactionId stored in our system we can skip the tag and CyberSource will try to find a networkTransactionId in their own system to fill the information in. The rep also told us that passing a blank tag prevents that behavior, that's why in this PR we're making a change from passing an empty networkTransactionId tag to not passing it at all.

What?
Avoid xml empty tag subsequentAuthTransactionID for cybersource