### PR TITLE
Braintree: fix a bug in the store method when payment_method_nonce was passed as empty string

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -213,7 +213,7 @@ module ActiveMerchant #:nodoc:
 
       def add_customer_with_credit_card(creditcard, options)
         commit do
-          if options[:payment_method_nonce]
+          if options[:payment_method_nonce].present?
             credit_card_params = { payment_method_nonce: options[:payment_method_nonce] }
           else
             credit_card_params = {
@@ -294,7 +294,7 @@ module ActiveMerchant #:nodoc:
             :last_name => creditcard.last_name,
             :email => scrub_email(options[:email])
           }
-          
+
           parameters[:credit_card] = credit_card_params unless partial_credit_card_account_update?(creditcard)
           parameters[:device_data] = options[:device_data] if options[:device_data]
 

--- a/test/remote/gateways/remote_braintree_blue_test.rb
+++ b/test/remote/gateways/remote_braintree_blue_test.rb
@@ -119,8 +119,14 @@ class RemoteBraintreeBlueTest < Test::Unit::TestCase
     assert_equal 'OK', response.message
   end
 
-  def test_successful_store_with_invalid_card
+  def test_successful_store_with_valid_card
     assert response = @gateway.store(@credit_card)
+    assert_success response
+    assert_equal 'OK', response.message
+  end
+
+  def test_successful_store_with_valid_card_and_empty_payment_method_nonce
+    assert response = @gateway.store(@credit_card, payment_method_nonce: "")
     assert_success response
     assert_equal 'OK', response.message
   end


### PR DESCRIPTION
This will fix an error in the store method when payment_method_nonce was passed as an empty string