### PR TITLE
Rails 5.2.x compatibility

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '<= 5.2')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 6.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
Current restrictions allow for 5.2.0 only. 