### PR TITLE
[internal] Add ability to pass order failure message to ActiveMerchant 

### DIFF
--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -34,6 +34,8 @@ module ActiveMerchant
       end
 
       def purchase(options)
+        return failed_order_response(options) if options[:order_failure_message].present?
+
         MultiResponse.new.tap do |r|
           order_exists = nil
           r.process do
@@ -162,6 +164,13 @@ module ActiveMerchant
         else
           ActiveMerchant::Billing::Response.new(false, "Customer '#{customer_vault_id}' not found", {exists: false})
         end
+      end
+
+      def failed_order_response(options)
+        ActiveMerchant::Billing::Response.new(
+          false,
+          options[:order_failure_message]
+        )
       end
 
       def headers(options)

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -153,6 +153,12 @@ class DigitalRiverTest < Test::Unit::TestCase
     assert_equal "A parameter is missing. (missing_parameter)", response.message
   end
 
+  def test_unsuccessful_purchase_passed_order_failure_message
+    assert response = @gateway.purchase(order_failure_message: 'Order failed')
+    assert_failure response
+    assert_equal "Order failed", response.message
+  end
+
   def test_purchase_with_order_in_review_state
     DigitalRiver::ApiClient
       .expects(:get)


### PR DESCRIPTION
This will add support for passing order_failure_message to the ActiveMerchant's purchase method