### PR TITLE
Add Refunds support to DigitalRiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', branch: 'PGT-1101-add-refunds'
+gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git'
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git'
+gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', branch: 'PGT-1101-add-refunds'
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -69,6 +69,26 @@ module ActiveMerchant
         end
       end
 
+      def refund(amount, order_id, options)
+        params =
+          {
+            'order_id' => order_id,
+            'currency' => options[:currency],
+            'amount' => amount,
+            'reason' => options[:reason],
+            'metadata' => options[:metadata],
+          }
+        result = @digital_river_gateway.refund.create(params)
+
+        ActiveMerchant::Billing::Response.new(
+          result.success?,
+          message_from_result(result),
+          {
+            refund_id: (result.value!.id if result.success?)
+          }
+        )
+      end
+
       private
 
       def create_fulfillment(order_id, items)

--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -69,12 +69,13 @@ module ActiveMerchant
         end
       end
 
-      def refund(amount, _transaction_id, options)
+      def refund(money, _transaction_id, options)
+        currency = options[:currency] || currency(money)
         params =
           {
             'order_id' => options[:order_id],
-            'currency' => options[:currency],
-            'amount' => amount.amount,
+            'currency' => currency.upcase,
+            'amount' => localized_amount(money, currency).to_f,
             'reason' => options[:memo],
             'metadata' => options[:metadata],
           }

--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -69,13 +69,13 @@ module ActiveMerchant
         end
       end
 
-      def refund(amount, order_id, options)
+      def refund(amount, _transaction_id, options)
         params =
           {
-            'order_id' => order_id,
+            'order_id' => options[:order_id],
             'currency' => options[:currency],
-            'amount' => amount,
-            'reason' => options[:reason],
+            'amount' => amount.amount,
+            'reason' => options[:memo],
             'metadata' => options[:metadata],
           }
         result = @digital_river_gateway.refund.create(params)

--- a/test/remote/gateways/remote_digital_river_test.rb
+++ b/test/remote/gateways/remote_digital_river_test.rb
@@ -162,7 +162,7 @@ class RemoteDigitalRiverTest < Test::Unit::TestCase
     order = order_factory.find_or_create_complete.value!
     options = { order_id: order.id, currency: 'USD' }
 
-    assert response = @gateway.refund(order.total_amount * 100, nil, options)
+    assert response = @gateway.refund(order.total_amount * 1000, nil, options)
     assert_failure response
     assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
   end

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -166,6 +166,63 @@ class DigitalRiverTest < Test::Unit::TestCase
     assert_equal "in_review", response.params["order_state"]
   end
 
+  def test_successful_full_refund
+    DigitalRiver::ApiClient
+      .expects(:post)
+      .with("/refunds", anything)
+      .returns(successful_full_refund_response)
+
+    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    assert_success response
+    assert_equal "OK", response.message
+    assert_equal "re_123", response.params['refund_id']
+  end
+
+  def test_successful_partial_refund
+    DigitalRiver::ApiClient
+      .expects(:post)
+      .with("/refunds", anything)
+      .returns(successful_partial_refund_response)
+
+    assert response = @gateway.refund(1.99, '123456780012', currency: 'USD')
+    assert_success response
+    assert_equal "OK", response.message
+    assert_equal "re_456", response.params['refund_id']
+  end
+
+  def test_unsuccessful_refund_order_doesnt_exist
+    DigitalRiver::ApiClient
+      .expects(:post)
+      .with("/refunds", anything)
+      .returns(unsuccessful_refund_order_doesnt_exist_response)
+
+    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    assert_failure response
+    assert_equal "Requisition not found. (invalid_parameter)", response.message
+  end
+
+  def test_unsuccessful_refund_order_in_fulfilled_state
+    DigitalRiver::ApiClient
+      .expects(:post)
+      .with("/refunds", anything)
+      .returns(unsuccessful_refund_order_in_fulfilled_state_response)
+
+    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    assert_failure response
+    assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
+  end
+
+  def test_unsuccessful_refund_amount_larger_than_available
+    DigitalRiver::ApiClient
+      .expects(:post)
+      .with("/refunds", anything)
+      .returns(unsuccessful_refund_amount_larger_than_available_response)
+
+    assert response = @gateway.refund(10.00, '123456780012', currency: 'USD')
+    assert_failure response
+    assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
+  end
+
   def succcessful_customer_response
     stub(
       success?: true,
@@ -618,6 +675,80 @@ class DigitalRiverTest < Test::Unit::TestCase
             refunded: false,
             source_id: "source",
             type: "merchant_initiated"
+          }
+        ]
+      }
+    )
+  end
+
+  def successful_full_refund_response
+    stub(
+      success?: true,
+      parsed_response: {
+        id: "re_123",
+        currency: "USD",
+        amount: 0.999e1,
+        refunded_amount: 0.0,
+        state: "pending",
+      }
+    )
+  end
+
+  def successful_partial_refund_response
+    stub(
+      success?: true,
+      parsed_response: {
+        id: "re_456",
+        currency: "USD",
+        amount: 0.199e1,
+        refunded_amount: 0.0,
+        state: "pending",
+      }
+    )
+  end
+
+  def unsuccessful_refund_order_doesnt_exist_response
+    stub(
+      success?: false,
+      parsed_response: {
+        type: "bad_request",
+        errors: [
+          {
+            code: "invalid_parameter",
+            parameter: "order",
+            message: "Requisition not found."
+          }
+        ]
+      }
+    )
+  end
+
+  def unsuccessful_refund_order_in_fulfilled_state_response
+    stub(
+      success?: false,
+      parsed_response: {
+        type: "bad_request",
+        errors: [
+          {
+            code: "invalid_parameter",
+            parameter: "amountRequested",
+            message: "The requested refund amount is greater than the available amount."
+          }
+        ]
+      }
+    )
+  end
+
+  def unsuccessful_refund_amount_larger_than_available_response
+    stub(
+      success?: false,
+      parsed_response: {
+        type: "bad_request",
+        errors: [
+          {
+            code: "invalid_parameter",
+            parameter: "amountRequested",
+            message: "The requested refund amount is greater than the available amount."
           }
         ]
       }

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -172,7 +172,8 @@ class DigitalRiverTest < Test::Unit::TestCase
       .with("/refunds", anything)
       .returns(successful_full_refund_response)
 
-    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    options = { order_id: '123456780012', currency: 'USD' }
+    assert response = @gateway.refund(9.99, nil, options)
     assert_success response
     assert_equal "OK", response.message
     assert_equal "re_123", response.params['refund_id']
@@ -184,7 +185,8 @@ class DigitalRiverTest < Test::Unit::TestCase
       .with("/refunds", anything)
       .returns(successful_partial_refund_response)
 
-    assert response = @gateway.refund(1.99, '123456780012', currency: 'USD')
+    options = { order_id: '123456780012', currency: 'USD' }
+    assert response = @gateway.refund(1.99, nil, options)
     assert_success response
     assert_equal "OK", response.message
     assert_equal "re_456", response.params['refund_id']
@@ -196,7 +198,8 @@ class DigitalRiverTest < Test::Unit::TestCase
       .with("/refunds", anything)
       .returns(unsuccessful_refund_order_doesnt_exist_response)
 
-    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    options = { order_id: '123456780012', currency: 'USD' }
+    assert response = @gateway.refund(9.99, nil, options)
     assert_failure response
     assert_equal "Requisition not found. (invalid_parameter)", response.message
   end
@@ -207,7 +210,8 @@ class DigitalRiverTest < Test::Unit::TestCase
       .with("/refunds", anything)
       .returns(unsuccessful_refund_order_in_fulfilled_state_response)
 
-    assert response = @gateway.refund(9.99, '123456780012', currency: 'USD')
+    options = { order_id: '123456780012', currency: 'USD' }
+    assert response = @gateway.refund(9.99, nil, options)
     assert_failure response
     assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
   end
@@ -218,7 +222,8 @@ class DigitalRiverTest < Test::Unit::TestCase
       .with("/refunds", anything)
       .returns(unsuccessful_refund_amount_larger_than_available_response)
 
-    assert response = @gateway.refund(10.00, '123456780012', currency: 'USD')
+    options = { order_id: '123456780012', currency: 'USD' }
+    assert response = @gateway.refund(10.00, nil, options)
     assert_failure response
     assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
   end


### PR DESCRIPTION
Jira: https://chargify.atlassian.net/jira/software/projects/PGT/boards/32?selectedIssue=PGT-1101

* Support refunds - both full and partial.
* DigitalRiver expects full amounts (e.g. 1.01 USD) not cents
* Remote tests utilize an order factory which looks for an existing order or creates a new one, which means it waits for the order's fulfillment for 60 seconds at most

![Screenshot 2021-06-16 at 12 34 45](https://user-images.githubusercontent.com/7498713/122206097-45bcf500-cea1-11eb-923b-a25b856d4655.png)
