### PR TITLE
[DigitalRiver] Add unstore action

### DIFF
--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -33,6 +33,22 @@ module ActiveMerchant
         end
       end
 
+      def unstore(payment_method, options)
+        customer_id = options[:customer_vault_token]
+        result = @digital_river_gateway
+          .customer
+          .detach_source(
+            customer_id,
+            payment_method
+          )
+        ActiveMerchant::Billing::Response.new(
+          result.success?,
+          message_from_result(result),
+          { customer_id: customer_id },
+          authorization: customer_id
+        )
+      end
+
       def purchase(options)
         return failed_order_response(options) if options[:order_failure_message].present?
 

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -234,6 +234,49 @@ class DigitalRiverTest < Test::Unit::TestCase
     assert_equal "The requested refund amount is greater than the available amount. (invalid_parameter)", response.message
   end
 
+  def test_successful_unstore
+    DigitalRiver::ApiClient
+      .expects(:delete)
+      .with("/customers/123/sources/456", anything)
+      .returns(successful_unstore_response)
+
+    assert response = @gateway.unstore('456', { customer_vault_token: '123' })
+    assert_success response
+  end
+
+  def test_unsuccessful_unstore
+    DigitalRiver::ApiClient
+      .expects(:delete)
+      .with("/customers/123/sources/456", anything)
+      .returns(unsuccessful_unstore_response)
+
+    assert response = @gateway.unstore('456', { customer_vault_token: '123' })
+    assert_failure response
+  end
+
+  def unsuccessful_unstore_response
+    stub(
+      success?: false,
+      parsed_response: {
+        type: "conflict",
+        errors: [
+          {
+            code: "not_found",
+            parameter: "sourceId",
+            message: "Source 'ea9e87a7-9f81-4448-82e3-d3028ea953c4' has not been attached to the customer."
+          }
+        ]
+      }
+    )
+  end
+
+  def successful_unstore_response
+    stub(
+      success?: false,
+      parsed_response: {}
+    )
+  end
+
   def succcessful_customer_response
     stub(
       success?: true,

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -272,7 +272,7 @@ class DigitalRiverTest < Test::Unit::TestCase
 
   def successful_unstore_response
     stub(
-      success?: false,
+      success?: true,
       parsed_response: {}
     )
   end


### PR DESCRIPTION
This PR adds an unstore action which wraps the detach_source endpoint for DigitalRiver gateway.
PR also adds one test case which was previously not possible to perform.