### PR TITLE
[bugfix] Add unstore and cancel mandate to gocardless gateway

### DIFF
--- a/lib/active_merchant/billing/gateways/go_cardless.rb
+++ b/lib/active_merchant/billing/gateways/go_cardless.rb
@@ -59,6 +59,10 @@ module ActiveMerchant #:nodoc:
         commit(:delete, "/customers/#{customer_id}", nil, options)
       end
 
+      def cancel_mandate(mandate, options = {})
+        commit(:post, "/mandates/#{mandate}/actions/cancel", options)
+      end
+
       def refund(money, identification, options = {})
         res = nil
         money_in_cents = money.respond_to?(:cents) ? money.cents : money.to_i

--- a/lib/active_merchant/billing/gateways/go_cardless.rb
+++ b/lib/active_merchant/billing/gateways/go_cardless.rb
@@ -55,6 +55,10 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def unstore(customer_id, options = {})
+        commit(:delete, "/customers/#{customer_id}", nil, options)
+      end
+
       def refund(money, identification, options = {})
         res = nil
         money_in_cents = money.respond_to?(:cents) ? money.cents : money.to_i
@@ -104,7 +108,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def parse(response)
-        JSON.parse(response)
+        JSON.parse(response || '{}')
       end
 
       def commit(method, action, params, options={})

--- a/lib/active_merchant/billing/gateways/go_cardless.rb
+++ b/lib/active_merchant/billing/gateways/go_cardless.rb
@@ -100,6 +100,8 @@ module ActiveMerchant #:nodoc:
       private
 
       def test?
+        return true if @options[:access_token].nil?
+
         @options[:access_token].start_with?('sandbox_')
       end
 


### PR DESCRIPTION
Why?
https://chargify.atlassian.net/browse/PGT-1217
Payment profiles in gocardless (temporary customers) from chargify.js remain in gocardless gateway, although we can remove them.

What?
The following PR introduce changes in conduit layer required to fix the above issue:

- Add unstore to gocardless gateway

Related PR's:
- [conduit] https://github.com/chargify/conduit/pull/343
- [chargify] https://github.com/chargify/chargify/pull/19428