### PR TITLE
[internal] Add support for passing debug_output option to DigitalRiver::Gateway

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "v4"
+# gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "v4"
+gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "PGT-1141-raw-gateway-logging-support"
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'jruby-openssl', :platforms => :jruby
-# gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "v4"
-gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "PGT-1141-raw-gateway-logging-support"
+gem 'digital_river', git: 'git@github.com:/chargify/digital_river.git', ref: "v7"
 
 group :test, :remote_test do
   # gateway-specific dependencies, keeping these gems out of the gemspec

--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -8,7 +8,7 @@ module ActiveMerchant
         super
 
         token = options[:token]
-        @digital_river_gateway = DigitalRiver::Gateway.new(token)
+        @digital_river_gateway = DigitalRiver::Gateway.new(token, wiredump_device)
       end
 
       def store(payment_method, options = {})
@@ -106,6 +106,15 @@ module ActiveMerchant
             refund_id: (result.value!.id if result.success?)
           }
         )
+      end
+
+      def supports_scrubbing?
+        true
+      end
+
+      def scrub(transcript)
+        transcript
+          .gsub(%r((Authorization: Bearer )\w+)i, '\1[FILTERED]\2')
       end
 
       private

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -254,6 +254,11 @@ class DigitalRiverTest < Test::Unit::TestCase
     assert_failure response
   end
 
+  def test_scrub
+    assert @gateway.supports_scrubbing?
+    assert_equal @gateway.scrub(pre_scrubbed), post_scrubbed
+  end
+
   def unsuccessful_unstore_response
     stub(
       success?: false,
@@ -815,5 +820,31 @@ class DigitalRiverTest < Test::Unit::TestCase
         ]
       }
     )
+  end
+
+  def pre_scrubbed
+    %q{
+      opening connection to api.digitalriver.com:443...
+      opened
+      starting SSL for api.digitalriver.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /customers HTTP/1.1\r\nAuthorization: Bearer sk_test_a3bd3f2ba5db4e2db94dd6b02b4dec33\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.digitalriver.com\r\nContent-Length: 202\r\n\r\n"
+      <- "{\"email\":\"holdpass@fraud.com\",\"shipping\":{\"name\":\"Jane Doe\",\"organization\":null,\"phone\":\"123456789\",\"address\":{\"line1\":\"Test\",\"line2\":\"\",\"city\":\"Test\",\"state\":\"AL\",\"postalCode\":\"12345\",\"country\":\"US\"}}}"
+      -> "HTTP/1.1 201 \r\n"
+      -> "access-control-allow-credentials: true\r\n"
+    }
+  end
+
+  def post_scrubbed
+    %q{
+      opening connection to api.digitalriver.com:443...
+      opened
+      starting SSL for api.digitalriver.com:443...
+      SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
+      <- "POST /customers HTTP/1.1\r\nAuthorization: Bearer [FILTERED]\r\nContent-Type: application/json\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nConnection: close\r\nHost: api.digitalriver.com\r\nContent-Length: 202\r\n\r\n"
+      <- "{\"email\":\"holdpass@fraud.com\",\"shipping\":{\"name\":\"Jane Doe\",\"organization\":null,\"phone\":\"123456789\",\"address\":{\"line1\":\"Test\",\"line2\":\"\",\"city\":\"Test\",\"state\":\"AL\",\"postalCode\":\"12345\",\"country\":\"US\"}}}"
+      -> "HTTP/1.1 201 \r\n"
+      -> "access-control-allow-credentials: true\r\n"
+    }
   end
 end


### PR DESCRIPTION
This will pass wiredump_device as the debug_option param to the DigitalRiver::Gateway