### PR TITLE
[DigitalRiver] Fix fetching source

### DIFF
--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -124,8 +124,11 @@ module ActiveMerchant
 
       def get_charge_capture_id(order_id)
         charges = nil
+        sources = nil
         retry_until(2, "charge not found", 0.5) do
-          charges = @digital_river_gateway.order.find(order_id).value!.payment.charges
+          order = @digital_river_gateway.order.find(order_id).value!
+          charges = order.payment.charges
+          sources = order.payment.sources
           charges&.first.present?
         end
 
@@ -142,7 +145,7 @@ module ActiveMerchant
             order_id: order_id,
             charge_id: charges.first.id,
             capture_id: captures.first.id,
-            source_id: charges.first.source_id
+            source_id: sources.detect { |s| s.type == 'creditCard' }.id
           },
           authorization: captures.first.id
         )

--- a/test/unit/gateways/digital_river_test.rb
+++ b/test/unit/gateways/digital_river_test.rb
@@ -559,33 +559,33 @@ class DigitalRiverTest < Test::Unit::TestCase
               source_id: "source",
               type: "merchant_initiated"
             }
-          ]
-        },
-        sources:  [
-          {
-            id: "source",
-            type: "creditCard",
-            amount: 249.99,
-            owner:{
-              first_name: "William",
-              last_name: "Brown",
-              email: "testing@example.com",
-              address:  {
-                line1: "10380 Bren Road West",
-                city: "Minnetonka",
-                postal_code: "55343",
-                state: "MN",
-                country: "US"
+          ],
+          sources:  [
+            {
+              id: "source",
+              type: "creditCard",
+              amount: 249.99,
+              owner:{
+                first_name: "William",
+                last_name: "Brown",
+                email: "testing@example.com",
+                address:  {
+                  line1: "10380 Bren Road West",
+                  city: "Minnetonka",
+                  postal_code: "55343",
+                  state: "MN",
+                  country: "US"
+                }
+              },
+              credit_card: {
+                brand: "Visa",
+                expiration_month: 7,
+                expiration_year: 2027,
+                last_four_digits: "1111"
               }
-            },
-            credit_card: {
-              brand: "Visa",
-              expiration_month: 7,
-              expiration_year: 2027,
-              last_four_digits: "1111"
             }
-          }
-        ]
+          ]
+        }
       }
     )
   end
@@ -712,33 +712,33 @@ class DigitalRiverTest < Test::Unit::TestCase
               source_id: "source",
               type: "merchant_initiated"
             }
-          ]
-        },
-        sources:  [
-          {
-            id: "source",
-            type: "creditCard",
-            amount: 249.99,
-            owner:{
-              first_name: "William",
-              last_name: "Brown",
-              email: "testing@example.com",
-              address:  {
-                line1: "10380 Bren Road West",
-                city: "Minnetonka",
-                postal_code: "55343",
-                state: "MN",
-                country: "US"
+          ],
+          sources:  [
+            {
+              id: "source",
+              type: "creditCard",
+              amount: 249.99,
+              owner:{
+                first_name: "William",
+                last_name: "Brown",
+                email: "testing@example.com",
+                address:  {
+                  line1: "10380 Bren Road West",
+                  city: "Minnetonka",
+                  postal_code: "55343",
+                  state: "MN",
+                  country: "US"
+                }
+              },
+              credit_card: {
+                brand: "Visa",
+                expiration_month: 7,
+                expiration_year: 2027,
+                last_four_digits: "1111"
               }
-            },
-            credit_card: {
-              brand: "Visa",
-              expiration_month: 7,
-              expiration_year: 2027,
-              last_four_digits: "1111"
             }
-          }
-        ]
+          ]
+        }
       }
     )
   end


### PR DESCRIPTION
This PR fixes the way we fetch the source_id when performing a purchase. We exclude anything that is not a `creditCard`.