### PR TITLE
[internal] increase the capture timeout limit from 2 to 5 seconds for Digital River

### DIFF
--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -116,7 +116,7 @@ module ActiveMerchant
       def get_charge_capture_id(order_id)
         charges = nil
         sources = nil
-        retry_until(2, "charge not found", 0.5) do
+        retry_until(5, "charge not found", 0.5) do
           order = @digital_river_gateway.order.find(order_id).value!
           charges = order.payment.charges
           sources = order.payment.sources


### PR DESCRIPTION
This will increase the capture timeout limit from 2 to 5 seconds