### PR TITLE
[internal] increase the capture timeout limit from 2 to 5 seconds for Digital River

### DIFF
--- a/lib/active_merchant/billing/gateways/digital_river.rb
+++ b/lib/active_merchant/billing/gateways/digital_river.rb
@@ -125,7 +125,7 @@ module ActiveMerchant
 
         # for now we assume only one charge will be processed at one order
         captures = nil
-        retry_until(2, "capture not found", 0.5) do
+        retry_until(5, "capture not found", 0.5) do
           captures = @digital_river_gateway.charge.find(charges.first.id).value!.captures
           captures&.first.present?
         end


### PR DESCRIPTION
This will increase the capture timeout limit from 2 to 5 seconds.