### PR TITLE
[enhancement] add payment_method_token parameter for Braintree

### DIFF
--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -691,6 +691,7 @@ module ActiveMerchant #:nodoc:
         end
 
         parameters[:payment_method_nonce] = options[:three_ds_token] if options[:three_ds]
+        parameters[:payment_method_token] = options[:payment_method_token] if options[:payment_method_token]
         parameters
       end
 

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -690,7 +690,11 @@ module ActiveMerchant #:nodoc:
           }
         end
 
-        parameters[:payment_method_nonce] = options[:three_ds_token] if options[:three_ds]
+        if options[:three_ds]
+          parameters[:payment_method_nonce] = options[:payment_method_nonce] if parameters[:payment_method_nonce]
+          parameters[:payment_method_nonce] = options[:three_ds_token] if parameters[:three_ds_token]
+        end
+
         parameters[:payment_method_token] = options[:payment_method_token] if options[:payment_method_token]
         parameters
       end

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -690,13 +690,15 @@ module ActiveMerchant #:nodoc:
           }
         end
 
-        if options[:three_ds]
-          parameters[:payment_method_nonce] = options[:payment_method_nonce] if parameters[:payment_method_nonce]
-          parameters[:payment_method_nonce] = options[:three_ds_token] if parameters[:three_ds_token]
-        end
-
+        parameters[:payment_method_nonce] = find_payment_method_nonce(options) if options[:three_ds]
         parameters[:payment_method_token] = options[:payment_method_token] if options[:payment_method_token]
         parameters
+      end
+
+      def find_payment_method_nonce(options)
+        return options[:three_ds_token] if options[:three_ds_token] && !options[:three_ds_token].empty?
+
+        options[:three_ds_token] || options[:payment_method_nonce]
       end
 
       def partial_paypal_account_update?(paypal_account)

--- a/lib/active_merchant/billing/gateways/braintree_blue.rb
+++ b/lib/active_merchant/billing/gateways/braintree_blue.rb
@@ -698,7 +698,7 @@ module ActiveMerchant #:nodoc:
       def find_payment_method_nonce(options)
         return options[:three_ds_token] if options[:three_ds_token] && !options[:three_ds_token].empty?
 
-        options[:three_ds_token] || options[:payment_method_nonce]
+        options[:payment_method_nonce]
       end
 
       def partial_paypal_account_update?(paypal_account)


### PR DESCRIPTION
## Why:
PGT-1660
chargify/chargify#20477
https://github.com/chargify/conduit/pull/368
## What:
Add payment_method_token to braintree_blue request params
