### PR TITLE
[bugfix] Add live_url_prefix to live url

### DIFF
--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -16,7 +16,6 @@ module ActiveMerchant #:nodoc:
       PAYMENTS_API_VERSION = 'v51'
       PAL_API_VERSION = 'v49'
       PAL_TEST_URL = 'https://pal-test.adyen.com/pal/servlet/'
-      PAL_LIVE_URL = 'https://pal-live.adyen.com/pal/servlet/'
 
       STANDARD_ERROR_CODE_MAPPING = {
           '101' => STANDARD_ERROR_CODE[:incorrect_number],
@@ -390,13 +389,17 @@ module ActiveMerchant #:nodoc:
         "https://#{@url_prefix}-checkout-live.adyenpayments.com/"
       end
 
+      def pal_live_url
+        "https://#{@url_prefix}-pal-live.adyenpayments.com/pal/servlet/"
+      end
+
       def url(action)
         if test?
           use_pal_endpoint?(action) ? "#{PAL_TEST_URL}#{endpoint(action)}" : "#{test_url}#{endpoint(action)}"
         elsif @options[:subdomain]
           "https://#{@options[:subdomain]}-pal-live.adyenpayments.com/pal/servlet/#{endpoint(action)}"
         else
-          use_pal_endpoint?(action) ? "#{PAL_LIVE_URL}#{endpoint(action)}" : "#{live_url}#{endpoint(action)}"
+          use_pal_endpoint?(action) ? "#{pal_live_url}#{endpoint(action)}" : "#{live_url}#{endpoint(action)}"
         end
       end
 

--- a/lib/active_merchant/billing/gateways/adyen_checkout.rb
+++ b/lib/active_merchant/billing/gateways/adyen_checkout.rb
@@ -2,7 +2,6 @@ module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
     class AdyenCheckoutGateway < Gateway
       self.test_url = 'https://checkout-test.adyen.com/'
-      self.live_url = 'https://checkout-live.adyen.com/'
 
       self.supported_countries = %w(AT AU BE BG BR CH CY CZ DE DK EE ES FI FR GB GI GR HK HU IE IS IT LI LT LU LV MC MT MX NL NO PL PT RO SE SG SK SI US)
       self.default_currency = 'USD'
@@ -30,8 +29,8 @@ module ActiveMerchant #:nodoc:
       }
 
       def initialize(options={})
-        requires!(options, :username, :password, :merchant_account)
-        @username, @password, @merchant_account = options.values_at(:username, :password, :merchant_account)
+        requires!(options, :username, :password, :merchant_account, :url_prefix)
+        @username, @password, @merchant_account, @url_prefix = options.values_at(:username, :password, :merchant_account, :url_prefix)
         super
       end
 
@@ -385,6 +384,10 @@ module ActiveMerchant #:nodoc:
         return "Recurring/#{PAL_API_VERSION}/#{action}" if action == "disable"
 
         "#{PAYMENTS_API_VERSION}/#{action}"
+      end
+
+      def live_url
+        "https://#{@url_prefix}-checkout-live.adyenpayments.com/"
       end
 
       def url(action)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -17,9 +17,10 @@ adyen:
   merchant_account: ''
 
 adyen_checkout:
-  username: ''
-  password: ''
-  merchant_account: ''
+  username: 'ws@Company.Chargify692'
+  password: ':7}Y%_7sr}CZ(m&Gjh*2j8%v&'
+  merchant_account: 'Chargify692ECOM'
+  url_prefix: 'random-merchant'
 
 allied_wallet:
   site_id: site_id

--- a/test/remote/gateways/remote_adyen_checkout_test.rb
+++ b/test/remote/gateways/remote_adyen_checkout_test.rb
@@ -149,7 +149,7 @@ class RemoteAdyenCheckoutTest < Test::Unit::TestCase
   end
 
   def test_invalid_login
-    gateway = AdyenCheckoutGateway.new(username: '', password: '', merchant_account: '')
+    gateway = AdyenCheckoutGateway.new(username: '', password: '', merchant_account: '', url_prefix: '')
 
     response = gateway.purchase(@amount, @credit_card, @options)
     assert_failure response
@@ -184,7 +184,7 @@ class RemoteAdyenCheckoutTest < Test::Unit::TestCase
     card = credit_card('4242424242424242', month: 16)
     assert response = @gateway.purchase(@amount, card, @options)
     assert_failure response
-    assert_equal 'Expiry Date Invalid: Expiry month should be between 1 and 12 inclusive', response.message
+    assert_equal 'The provided Expiry Date is not valid.: Expiry month should be between 1 and 12 inclusive', response.message
   end
 
   def test_invalid_expiry_year_for_purchase

--- a/test/unit/gateways/adyen_checkout_test.rb
+++ b/test/unit/gateways/adyen_checkout_test.rb
@@ -7,7 +7,8 @@ class AdyenTest < Test::Unit::TestCase
     @gateway = AdyenCheckoutGateway.new(
         username: 'ws@adyenmerchant.com',
         password: 'password',
-        merchant_account: 'merchantAccount'
+        merchant_account: 'merchantAccount',
+        url_prefix: 'random-account'
     )
 
     @credit_card = credit_card('4111111111111111',


### PR DESCRIPTION
Why?
Adyen live mode was not working

What?
To switch to production (live mode) url we need merchant specific url prefix, we set it in chargify and pass to AM

Conduit: https://github.com/chargify/conduit/pull/369
Chargify: https://github.com/chargify/chargify/pull/20625