### PR TITLE
[bugfix] fix updating default credit card on Stripe by updating also default_payment_method

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -238,6 +238,8 @@ module ActiveMerchant #:nodoc:
 
               if options[:set_default] and r.success? and r.params['id'].present?
                 post[:default_card] = r.params['id']
+                post[:invoice_settings] = {}
+                post[:invoice_settings][:default_payment_method] = r.params['id']
               end
             end
 

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -1164,7 +1164,7 @@ stripe:
 
 # Working credentials, no need to replace
 stripe_destination:
-  stripe_user_id: "acct_17FRNfIPBJTitsen"
+  stripe_user_id: "acct_1K5HlrPT5iqVqrJn"
 
 # Externally verified bank account for testing
 stripe_verified_bank_account:


### PR DESCRIPTION
## WHY:
[PGT-2002](https://chargify.atlassian.net/browse/PGT-2002)

When merchant sets `invoice_settings[default_payment_method]` on customer Stripe object on his own, updating the card via SSP does not work, because credit card from  `invoice_settings[default_payment_method]` is preferred over `default_source`.

## WHAT:
It sets `invoice_settings[default_payment_method]` together with `default_source`.

conduit: https://github.com/chargify/conduit/pull/380
chargify: https://github.com/chargify/chargify/pull/21296