### PR TITLE
[bugfix] fix card update when added as payment method through Stripe API

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -409,6 +409,16 @@ module ActiveMerchant #:nodoc:
         end
       end
 
+      def customer_payment_method(customer_id, payment_method_id)
+        r = commit(:get, "customers/#{CGI.escape(customer_id)}/payment_methods/#{CGI.escape(payment_method_id)}")
+        raise r.message unless r.success?
+
+        OpenStruct.new(
+          id: r.params["id"],
+          last4: r.params.dig("card", "last4")
+        )
+      end
+
       def customer_payment_methods(customer, payment_type)
         r = commit(:get, "payment_methods?customer=#{customer}&type=#{payment_type}", nil, options)
         raise r.message unless r.success?

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -259,12 +259,13 @@ module ActiveMerchant #:nodoc:
         end
       end
 
-      def update(customer_id, card_id, options = {})
-        commit(:post, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_id)}", options, options)
-      end
-
-      def update_payment_method(payment_method_id, options = {})
-        commit(:post, "payment_methods/#{CGI.escape(payment_method_id)}", options, options)
+      def update(customer_id, card_or_payment_method_id, options = {})
+        case card_or_payment_method_id
+        when /^card_/
+          commit(:post, "customers/#{CGI.escape(customer_id)}/cards/#{CGI.escape(card_or_payment_method_id)}", options, options)
+        when /^pm_/
+          commit(:post, "payment_methods/#{CGI.escape(card_or_payment_method_id)}", options, options)
+        end
       end
 
       def update_customer(customer_id, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -343,7 +343,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if options[:three_d_secure]
-          payment_method = card_payment_method_for_customer(options[:customer])&.id
+          payment_method = card_payment_method_for_customer(options[:customer])
 
           if payment_method
             post[:confirmation_method] = "manual"
@@ -384,17 +384,11 @@ module ActiveMerchant #:nodoc:
 
       def card_payment_method_for_customer(customer)
         payment_methods = customer_payment_methods(customer, "card")
-        return OpenStruct.new(
-          id: payment_methods.default_payment_method,
-          type: "payment_method"
-        ) if payment_methods.default_payment_method
+        return payment_methods.default_payment_method if payment_methods.default_payment_method
 
         # in last resort we choose default source
         default_source = customer_default_source(customer)
-        return OpenStruct.new(
-          id: default_source,
-          type: "source"
-        ) if default_source
+        return default_source if default_source
 
         if payment_methods.count > 1
           raise "Customer has more than one payment method but doesn't have default one."
@@ -807,10 +801,6 @@ module ActiveMerchant #:nodoc:
 
         Array(payment_method_type)
       end
-
-      # def card_payment_methods_for_customer(customer_id)
-      #   commit(:get, "customers/#{CGI.escape(customer_id)}/payment_methods?type=card")
-      # end
 
       def initial_options_for_sepa_direct_debit(bank_account, options)
         {

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -342,7 +342,7 @@ module ActiveMerchant #:nodoc:
         end
 
         if options[:three_d_secure]
-          payment_method = card_payment_method_for_customer(options[:customer]).id
+          payment_method = card_payment_method_for_customer(options[:customer])&.id
 
           if payment_method
             post[:confirmation_method] = "manual"


### PR DESCRIPTION
#### Reference link
https://chargify.atlassian.net/browse/PGT-2001

#### Why?
Some merchant encountered a problem with updating payment profiles in Stripe when credit card was created as a payment method rather than a card through the Stripe API. In result the 500 errors were raised.

#### What?
Both `conduit` and `activemerchant` have been updated to be able to update payment methods as well, depending on customer's default payment method and default source.

Conduit: https://github.com/chargify/conduit/pull/383
Chargify: https://github.com/chargify/chargify/pull/21396