### PR TITLE
[internal] scrub stripe bank account and routing number in gateway logs

### DIFF
--- a/lib/active_merchant/billing/gateways/forte.rb
+++ b/lib/active_merchant/billing/gateways/forte.rb
@@ -168,6 +168,7 @@ module ActiveMerchant #:nodoc:
         transcript
           .gsub(/(Authorization: Basic )\w+/, '\1[FILTERED]')
           .gsub(/(account_number)\W+\d+/, '\1[FILTERED]')
+          .gsub(/(routing_number)\W+\d+/, '\1[FILTERED]')
           .gsub(/(card_verification_value)\W+\d+/, '\1[FILTERED]')
       end
 

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -313,7 +313,14 @@ module ActiveMerchant #:nodoc:
           gsub(%r((card\[swipe_data\]=)[^&]+(&?)), '\1[FILTERED]\2').
           gsub(%r((card\[encrypted_pin\]=)[^&]+(&?)), '\1[FILTERED]\2').
           gsub(%r((card\[encrypted_pin_key_id\]=)[\w=]+(&?)), '\1[FILTERED]\2').
-          gsub(%r((card\[emv_auth_data\]=)[^&]+(&?)), '\1[FILTERED]\2')
+          gsub(%r((card\[emv_auth_data\]=)[^&]+(&?)), '\1[FILTERED]\2').
+          gsub(%r((bank_account\[account_number\]=)\d+), '\1[FILTERED]').
+          gsub(%r((bank_account\[routing_number\]=)\d+), '\1[FILTERED]').
+          gsub(%r((\\"routing_number\\": \\")\d+), '\1[FILTERED]').
+          gsub(%r((au_becs_debit\[bsb_number\]=)\d+), '\1[FILTERED]').
+          gsub(%r((au_becs_debit\[account_number\]=)\d+), '\1[FILTERED]').
+          gsub(%r((\\"bsb_number\\": \\")\d+), '\1[FILTERED]').
+          gsub(%r((sepa_debit\[iban\]=)[A-Z]{2}\d+), '\1[FILTERED]')
       end
 
       def supports_network_tokenization?

--- a/test/remote/gateways/remote_forte_test.rb
+++ b/test/remote/gateways/remote_forte_test.rb
@@ -443,14 +443,19 @@ class RemoteForteTest < Test::Unit::TestCase
 
   def test_transcript_scrubbing
     @credit_card.verification_value = 789
-    transcript = capture_transcript(@gateway) do
+    credit_card_transcript = capture_transcript(@gateway) do
       @gateway.purchase(@amount, @credit_card, @options)
     end
+    credit_card_transcript = @gateway.scrub(credit_card_transcript)
+    assert_scrubbed(@credit_card.number, credit_card_transcript)
+    assert_scrubbed(@credit_card.verification_value, credit_card_transcript)
 
-    transcript = @gateway.scrub(transcript)
-
-    assert_scrubbed(@credit_card.number, transcript)
-    assert_scrubbed(@credit_card.verification_value, transcript)
+    check_transcript = capture_transcript(@gateway) do
+      @gateway.store(@check)
+    end
+    check_transcript = @gateway.scrub(check_transcript)
+    assert_scrubbed(@check.account_number, check_transcript)
+    assert_scrubbed(@check.routing_number, check_transcript)
   end
 
   private


### PR DESCRIPTION
## WHY:
[PGT-2093](https://chargify.atlassian.net/browse/PGT-2093)

## WHAT:
- bank account number and routing number get scrubbed for ACH, SEPA direct debit, and BECS direct debit in logs from Stripe
- bank account number gets scrubbed for ACH from Forte gateway


Chargify: https://github.com/chargify/chargify/pull/21532
conduit: https://github.com/chargify/conduit/pull/385