### PR TITLE
[bugfix] scrub invalid byte sequence before parsing xml response from Windcave

### DIFF
--- a/lib/active_merchant/billing/gateways/payment_express.rb
+++ b/lib/active_merchant/billing/gateways/payment_express.rb
@@ -310,7 +310,7 @@ module ActiveMerchant #:nodoc:
       def parse(xml_string)
         response = {}
 
-        xml = REXML::Document.new(xml_string)
+        xml = REXML::Document.new(xml_string.scrub)
 
         # Gather all root elements such as HelpText
         xml.elements.each('Txn/*') do |element|

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -75,7 +75,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
       :password => ''
     )
     assert response = gateway.purchase(@amount, @credit_card, @options)
-    assert_match %r{error}i, response.message
+    assert_match %r{Invalid Credentials}i, response.message
     assert_failure response
   end
 

--- a/test/remote/gateways/remote_payment_express_test.rb
+++ b/test/remote/gateways/remote_payment_express_test.rb
@@ -66,7 +66,7 @@ class RemotePaymentExpressTest < Test::Unit::TestCase
   def test_failed_capture
     assert response = @gateway.capture(@amount, '999')
     assert_failure response
-    assert_equal 'DpsTxnRef Invalid', response.message
+    assert_equal 'The transaction has not been processed.', response.message
   end
 
   def test_invalid_login

--- a/test/unit/gateways/payment_express_test.rb
+++ b/test/unit/gateways/payment_express_test.rb
@@ -82,6 +82,19 @@ class PaymentExpressTest < Test::Unit::TestCase
     assert_equal 'my-custom-id', response.token
   end
 
+  def test_successful_card_store_with_invalid_byte_sequence_in_gateway_response
+    invalid_utf8_byte_sequence = "H\xE5VARD - Håvard "
+    @gateway.expects(:ssl_post).returns(
+      successful_store_response.gsub("<CardHolderName>", "<CardHolderName>#{invalid_utf8_byte_sequence}")
+    )
+
+    assert response = @gateway.store(@visa)
+    assert_success response
+    assert response.test?
+    assert_equal '0000030000141581', response.authorization
+    assert_equal response.authorization, response.token
+  end
+
   def test_unsuccessful_card_store
     @gateway.expects(:ssl_post).returns(unsuccessful_store_response)
 


### PR DESCRIPTION
Windcave started to include invalid byte sequence for non-ASCI characters which resulted with `REXML::ParseException`

before: 
```ruby
REXML::Document.new("<CardHolderName>H\xE5VARD</CardHolderName>")
  => REXML::ParseException
```
after:
```ruby
REXML::Document.new("<CardHolderName>H\xE5VARD</CardHolderName>".scrub)
  => ok
```