### PR TITLE
[feature] Add CEDP/Product 3 data support for Stripe PaymentIntents

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -572,6 +572,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
+        if cedp_data_present?(options)
+          add_cedp_data(post, options)
+          return
+        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -584,6 +588,17 @@ module ActiveMerchant #:nodoc:
 
           level3[:line_items] = line_items if line_items.present?
         end
+      end
+
+      def cedp_data_present?(options)
+        options[:payment_details].present? && options[:amount_details].present?
+      end
+
+      def add_cedp_data(post, options)
+        post[:payment_details] = options[:payment_details]
+        post[:amount_details]  = options[:amount_details]
+        post[:payment_method_types] = ["card"]
+        @options.merge!(:version => '2025-04-30.preview')
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,7 +598,8 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        @options.merge!(:version => '2025-04-30.preview')
+        options[:version] = options.dig(:stripe_level3_version)
+        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -573,6 +573,7 @@ module ActiveMerchant #:nodoc:
 
       def add_level_3_data(post, options = {})
         if cedp_data_present?(options)
+          # CEDP/Product 3 replaces legacy Level 3 data.
           add_cedp_data(post, options)
           return
         end
@@ -676,7 +677,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,8 +598,6 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        options[:version] = options.dig(:stripe_level3_version)
-        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)
@@ -678,7 +676,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -384,7 +384,9 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_application_fee(post, options)
         add_destination(post, options)
-        add_level_3_data(post, options) if credit_card_payment?(options) && !physical_retail?(options)
+        if credit_card_payment?(options) && !physical_retail?(options)
+          cedp_data_present?(options) ? add_cedp_data(post, options) : add_level_3_data(post, options)
+        end
 
         post
       end
@@ -572,11 +574,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
-        if cedp_data_present?(options)
-          # CEDP/Product 3 replaces legacy Level 3 data.
-          add_cedp_data(post, options)
-          return
-        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -677,7 +674,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_api_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})


### PR DESCRIPTION
## Ticket
https://maxioevolution.atlassian.net/browse/PAY-2783

## Related
https://github.com/maxio-com/chargify/pull/27000

## What
We adding support for sending CEDP / Level 3 data to Stripe on each payment intent

## How
Adjusting the creation of this piece of payload to comply with the new format, which is still on preview.

## Notes
### About the `2025-04-30.preview` header
We’re now sending “payment line items” (Stripe’s new CEDP / Level 3-style data) when we create the PaymentIntent. This data goes in the `payment_details[...]` object (for example order_reference) and `amount_details[line_items][...]` (per-item info like product name, unit cost, quantity, tax). This feature is behind a public preview in Stripe, and Stripe requires that we send the preview API version header `2025-04-30.preview` on the request so those params are accepted and persisted. See Stripe’s `Payment line items` preview docs, which say: “You can use this public preview feature by including the version header `2025-04-30.preview` … You can now add the line items … by passing the `payment_details` and `amount_details` params when creating a PaymentIntent.”
[https://docs.stripe.com/payments/payment-line-items](https://docs.stripe.com/payments/payment-line-items)
[https://docs.stripe.com/changelog/basil/2025-04-30/payment-line-items](https://docs.stripe.com/changelog/basil/2025-04-30/payment-line-items)

### About the new key `payment_method_types: ['card']`
When we switched to that preview version, Stripe changed default behavior for payment methods. If you don’t tell Stripe which payment method types you want, Stripe will auto-enable every method you’ve turned on in the Dashboard. Some of those methods are redirect-based, so Stripe then requires a `return_url` on the PaymentIntent. To avoid that (we only charge cards, server-side, no redirects), we now explicitly send: `post[:payment_method_types] = ["card"]`

Stripe’s docs describe that you can either 
(a) pass `payment_method_types: ['card']` when creating the PaymentIntent, or 
(b) force `automatic_payment_methods[allow_redirects]=never`, to prevent redirect methods and skip the `return_url` requirement.
[https://docs.stripe.com/upgrades/manage-payment-methods](https://docs.stripe.com/upgrades/manage-payment-methods)
[https://docs.stripe.com/changelog/2023-08-16/automatic-payment-methods](https://docs.stripe.com/changelog/2023-08-16/automatic-payment-methods)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PaymentIntent/charge creation payload and Stripe API version header behavior; incorrect options or versioning could cause Stripe request validation errors or unexpected payment method requirements.
> 
> **Overview**
> Adds support for Stripe’s preview CEDP/payment line-item format by conditionally sending `payment_details` and `amount_details` (and forcing `payment_method_types: ["card"]`) when present, otherwise falling back to existing Level 3 `level3` payload generation.
> 
> Extends Stripe request version selection to prefer a new `options[:stripe_api_version]` over the existing `:version`/default when building the `Stripe-Version` header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30278333c33c2bf9bcf6b52b39fc02b478a0d1a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->