### PR TITLE
Refactor

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -384,7 +384,9 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_application_fee(post, options)
         add_destination(post, options)
-        add_level_3_data(post, options) if credit_card_payment?(options) && !physical_retail?(options)
+        if credit_card_payment?(options) && !physical_retail?(options)
+          cedp_data_present?(options) ? add_cedp_data(post, options) : add_level_3_data(post, options)
+        end
 
         post
       end
@@ -572,11 +574,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
-        if cedp_data_present?(options)
-          # CEDP/Product 3 replaces legacy Level 3 data.
-          add_cedp_data(post, options)
-          return
-        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -677,7 +674,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_api_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prioritizes CEDP/Product 3 data when building Stripe requests and updates API version configuration.
> 
> - In `create_post_for_auth_or_purchase`, if `credit_card` and not physical retail, now sends `CEDP` data (`payment_details`, `amount_details`) when present; otherwise falls back to `level3`
> - `add_level_3_data` no longer checks for or injects CEDP; it only adds Level 3 fields when `line_items` are present
> - Renames header version option from `options[:stripe_level3_version]` to `options[:stripe_api_version]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 808ad448bb59470391f848260bb79854370190ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->