### PR TITLE
[bugfix] Pay 2783 spike visa cedp stripe ab post revert

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -572,6 +572,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
+        if cedp_data_present?(options)
+          add_cedp_data(post, options)
+          return
+        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -584,6 +588,17 @@ module ActiveMerchant #:nodoc:
 
           level3[:line_items] = line_items if line_items.present?
         end
+      end
+
+      def cedp_data_present?(options)
+        options[:payment_details].present? && options[:amount_details].present?
+      end
+
+      def add_cedp_data(post, options)
+        post[:payment_details] = options[:payment_details]
+        post[:amount_details]  = options[:amount_details]
+        post[:payment_method_types] = ["card"]
+        @options.merge!(:version => '2025-04-30.preview')
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,7 +598,8 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        @options.merge!(:version => '2025-04-30.preview')
+        options[:version] = options.dig(:stripe_level3_version)
+        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -594,7 +594,7 @@ module ActiveMerchant #:nodoc:
 
       def add_cedp_data(post, options)
         post[:payment_details] = options[:payment_details]
-        post[:amount_details]  = options[:amount_details]
+        post[:amount_details] = sanitize_cedp_amount_details(options[:amount_details])
         post[:payment_method_types] = ["card"]
       end
 
@@ -607,7 +607,8 @@ module ActiveMerchant #:nodoc:
             unit_cost: item[:price_in_cents],
             quantity: item[:quantity],
             tax_amount: item[:tax_amount_in_cents],
-            discount_amount: item[:discount_amount_in_cents]
+            discount_amount: item[:discount_amount_in_cents],
+            unit_of_measure: sanitize_unit_of_measure(item[:unit_of_measure] || item[:unit_name])
           }
         end
       end
@@ -1012,6 +1013,25 @@ module ActiveMerchant #:nodoc:
           error_message: error["message"],
           parameters: parameters,
           tags: "level3,stripe"
+        )
+      end
+
+      def sanitize_unit_of_measure(value)
+        sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
+        sanitized.blank? ? 'each' : sanitized
+      end
+
+      def sanitize_cedp_amount_details(amount_details)
+        return amount_details unless amount_details&.dig(:line_items)
+      
+        amount_details.merge(
+          line_items: amount_details[:line_items].map do |item|
+            item.merge(
+              unit_of_measure: sanitize_unit_of_measure(
+                item[:unit_of_measure] || item[:unit_name]
+              )
+            )
+          end
         )
       end
     end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -573,6 +573,7 @@ module ActiveMerchant #:nodoc:
 
       def add_level_3_data(post, options = {})
         if cedp_data_present?(options)
+          # CEDP/Product 3 replaces legacy Level 3 data.
           add_cedp_data(post, options)
           return
         end
@@ -676,7 +677,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,8 +598,6 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        options[:version] = options.dig(:stripe_level3_version)
-        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)
@@ -678,7 +676,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -594,7 +594,7 @@ module ActiveMerchant #:nodoc:
 
       def add_cedp_data(post, options)
         post[:payment_details] = options[:payment_details]
-        post[:amount_details] = sanitize_cedp_amount_details(options[:amount_details])
+        post[:amount_details] = options[:amount_details]
         post[:payment_method_types] = ["card"]
       end
 
@@ -608,7 +608,7 @@ module ActiveMerchant #:nodoc:
             quantity: item[:quantity],
             tax_amount: item[:tax_amount_in_cents],
             discount_amount: item[:discount_amount_in_cents],
-            unit_of_measure: sanitize_unit_of_measure(item[:unit_of_measure] || item[:unit_name])
+            unit_of_measure: item[:unit_of_measure]
           }
         end
       end
@@ -1019,20 +1019,6 @@ module ActiveMerchant #:nodoc:
       def sanitize_unit_of_measure(value)
         sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
         sanitized.blank? ? 'each' : sanitized
-      end
-
-      def sanitize_cedp_amount_details(amount_details)
-        return amount_details unless amount_details&.dig(:line_items)
-      
-        amount_details.merge(
-          line_items: amount_details[:line_items].map do |item|
-            item.merge(
-              unit_of_measure: sanitize_unit_of_measure(
-                item[:unit_of_measure] || item[:unit_name]
-              )
-            )
-          end
-        )
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -384,7 +384,9 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_application_fee(post, options)
         add_destination(post, options)
-        add_level_3_data(post, options) if credit_card_payment?(options) && !physical_retail?(options)
+        if credit_card_payment?(options) && !physical_retail?(options)
+          cedp_data_present?(options) ? add_cedp_data(post, options) : add_level_3_data(post, options)
+        end
 
         post
       end
@@ -572,11 +574,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
-        if cedp_data_present?(options)
-          # CEDP/Product 3 replaces legacy Level 3 data.
-          add_cedp_data(post, options)
-          return
-        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -677,7 +674,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_api_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -1015,11 +1015,6 @@ module ActiveMerchant #:nodoc:
           tags: "level3,stripe"
         )
       end
-
-      def sanitize_unit_of_measure(value)
-        sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
-        sanitized.blank? ? 'each' : sanitized
-      end
     end
   end
 end


### PR DESCRIPTION
Ticket
https://maxioevolution.atlassian.net/browse/PAY-2783

What
When a product has discounts or components, the line_items array needs to be sanitized to use only alphanumeric chars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized payload change to optional Level 3 data; main risk is downstream Stripe validation/field compatibility.
> 
> **Overview**
> Updates Stripe Level 3 line-item mapping to also send `unit_of_measure` alongside existing fields (including `discount_amount`) when building `level3[:line_items]`.
> 
> Also applies a minor formatting-only tweak in `add_cedp_data` (no behavior change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90897155c9bc5cb4d844faf09c8d0fdc8c9e6e46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->