### PR TITLE
[bugfix] Pay 2783 spike Visa CEDP Stripe AB retry payment after CEDP format failure

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -572,6 +572,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
+        if cedp_data_present?(options)
+          add_cedp_data(post, options)
+          return
+        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -584,6 +588,17 @@ module ActiveMerchant #:nodoc:
 
           level3[:line_items] = line_items if line_items.present?
         end
+      end
+
+      def cedp_data_present?(options)
+        options[:payment_details].present? && options[:amount_details].present?
+      end
+
+      def add_cedp_data(post, options)
+        post[:payment_details] = options[:payment_details]
+        post[:amount_details]  = options[:amount_details]
+        post[:payment_method_types] = ["card"]
+        @options.merge!(:version => '2025-04-30.preview')
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,7 +598,8 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        @options.merge!(:version => '2025-04-30.preview')
+        options[:version] = options.dig(:stripe_level3_version)
+        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -594,7 +594,7 @@ module ActiveMerchant #:nodoc:
 
       def add_cedp_data(post, options)
         post[:payment_details] = options[:payment_details]
-        post[:amount_details]  = options[:amount_details]
+        post[:amount_details] = sanitize_cedp_amount_details(options[:amount_details])
         post[:payment_method_types] = ["card"]
       end
 
@@ -607,7 +607,8 @@ module ActiveMerchant #:nodoc:
             unit_cost: item[:price_in_cents],
             quantity: item[:quantity],
             tax_amount: item[:tax_amount_in_cents],
-            discount_amount: item[:discount_amount_in_cents]
+            discount_amount: item[:discount_amount_in_cents],
+            unit_of_measure: sanitize_unit_of_measure(item[:unit_of_measure] || item[:unit_name])
           }
         end
       end
@@ -1012,6 +1013,25 @@ module ActiveMerchant #:nodoc:
           error_message: error["message"],
           parameters: parameters,
           tags: "level3,stripe"
+        )
+      end
+
+      def sanitize_unit_of_measure(value)
+        sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
+        sanitized.blank? ? 'each' : sanitized
+      end
+
+      def sanitize_cedp_amount_details(amount_details)
+        return amount_details unless amount_details&.dig(:line_items)
+      
+        amount_details.merge(
+          line_items: amount_details[:line_items].map do |item|
+            item.merge(
+              unit_of_measure: sanitize_unit_of_measure(
+                item[:unit_of_measure] || item[:unit_name]
+              )
+            )
+          end
         )
       end
     end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -573,6 +573,7 @@ module ActiveMerchant #:nodoc:
 
       def add_level_3_data(post, options = {})
         if cedp_data_present?(options)
+          # CEDP/Product 3 replaces legacy Level 3 data.
           add_cedp_data(post, options)
           return
         end
@@ -676,7 +677,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -998,6 +998,7 @@ module ActiveMerchant #:nodoc:
         return response unless parameters[:amount_details].present?
         return response if response.success?
         return response unless cedp_related_error?(response)
+        return response unless cedp_related_error?(response.params.dig("error", "param").to_s)
 
         notify_hb(response.params["error"], parameters)
         parameters.delete(:amount_details)
@@ -1006,9 +1007,9 @@ module ActiveMerchant #:nodoc:
         commit(method, url, parameters, options)
       end
 
-      def cedp_related_error?(response)
-        response.params.dig("error", "param").to_s.start_with?("amount_details") ||
-          response.params.dig("error", "param").to_s.start_with?("payment_details")
+      def cedp_related_error?(error_param)
+        error_param.start_with?("amount_details") ||
+          error_param.start_with?("payment_details")
       end
 
       def notify_hb(error, parameters)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -598,8 +598,6 @@ module ActiveMerchant #:nodoc:
         post[:payment_details] = options[:payment_details]
         post[:amount_details]  = options[:amount_details]
         post[:payment_method_types] = ["card"]
-        options[:version] = options.dig(:stripe_level3_version)
-        options.delete(:stripe_level3_version)
       end
 
       def level_3_data_map_line_item(line_items)
@@ -678,7 +676,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_level3_version] ||options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -81,7 +81,7 @@ module ActiveMerchant #:nodoc:
             else
               post[:capture] = "false"
             end
-            level_three_data_commit(:post, 'charges', post, options)
+            cedp_data_commit(:post, 'charges', post, options)
           end
         end.responses.last
       end
@@ -115,7 +115,7 @@ module ActiveMerchant #:nodoc:
             if options[:payment_type] == "bank_account" && payment_method_types
               post[:payment_method_types] = payment_method_types
             end
-            level_three_data_commit(:post, use_payment_intents?(post, options) ? 'payment_intents' : 'charges', post, options)
+            cedp_data_commit(:post, use_payment_intents?(post, options) ? 'payment_intents' : 'charges', post, options)
           end
         end.responses.last
 
@@ -123,7 +123,7 @@ module ActiveMerchant #:nodoc:
         if options[:three_d_secure] && !r.success? && decline_code == "authentication_required"
           options[:three_d_secure] = "setup_future_usage"
           post = create_post_for_auth_or_purchase(money, payment, options)
-          r = level_three_data_commit(:post, 'payment_intents', post, options)
+          r = cedp_data_commit(:post, 'payment_intents', post, options)
         end
 
         r
@@ -993,26 +993,30 @@ module ActiveMerchant #:nodoc:
         !!options.dig(:metadata, :is_physical)
       end
 
-      def level_three_data_commit(method, url, parameters = nil, options = {})
-        level3 = parameters[:level3].present?
+      def cedp_data_commit(method, url, parameters = nil, options = {})
         response = commit(method, url, parameters, options)
-
-        return response unless level3
+        return response unless parameters[:amount_details].present?
         return response if response.success?
-        return response unless response&.params&.dig("error", "param") == "level3"
+        return response unless cedp_related_error?(response)
 
         notify_hb(response.params["error"], parameters)
-        parameters.delete(:level3)
+        parameters.delete(:amount_details)
+        parameters.delete(:payment_details)
 
         commit(method, url, parameters, options)
       end
 
+      def cedp_related_error?(response)
+        response.params.dig("error", "param").to_s.start_with?("amount_details") ||
+          response.params.dig("error", "param").to_s.start_with?("payment_details")
+      end
+
       def notify_hb(error, parameters)
         Honeybadger.notify(
-          "Failed to submit level 3 data",
+          "Failed to submit CEDP (former level3) data",
           error_message: error["message"],
           parameters: parameters,
-          tags: "level3,stripe"
+          tags: "level3,cedp,stripe"
         )
       end
     end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -997,7 +997,6 @@ module ActiveMerchant #:nodoc:
         response = commit(method, url, parameters, options)
         return response unless parameters[:amount_details].present?
         return response if response.success?
-        return response unless cedp_related_error?(response)
         return response unless cedp_related_error?(response.params.dig("error", "param").to_s)
 
         notify_hb(response.params["error"], parameters)

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -594,7 +594,7 @@ module ActiveMerchant #:nodoc:
 
       def add_cedp_data(post, options)
         post[:payment_details] = options[:payment_details]
-        post[:amount_details] = sanitize_cedp_amount_details(options[:amount_details])
+        post[:amount_details] = options[:amount_details]
         post[:payment_method_types] = ["card"]
       end
 
@@ -608,7 +608,7 @@ module ActiveMerchant #:nodoc:
             quantity: item[:quantity],
             tax_amount: item[:tax_amount_in_cents],
             discount_amount: item[:discount_amount_in_cents],
-            unit_of_measure: sanitize_unit_of_measure(item[:unit_of_measure] || item[:unit_name])
+            unit_of_measure: item[:unit_of_measure]
           }
         end
       end
@@ -1019,20 +1019,6 @@ module ActiveMerchant #:nodoc:
       def sanitize_unit_of_measure(value)
         sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
         sanitized.blank? ? 'each' : sanitized
-      end
-
-      def sanitize_cedp_amount_details(amount_details)
-        return amount_details unless amount_details&.dig(:line_items)
-      
-        amount_details.merge(
-          line_items: amount_details[:line_items].map do |item|
-            item.merge(
-              unit_of_measure: sanitize_unit_of_measure(
-                item[:unit_of_measure] || item[:unit_name]
-              )
-            )
-          end
-        )
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -384,7 +384,9 @@ module ActiveMerchant #:nodoc:
         add_metadata(post, options)
         add_application_fee(post, options)
         add_destination(post, options)
-        add_level_3_data(post, options) if credit_card_payment?(options) && !physical_retail?(options)
+        if credit_card_payment?(options) && !physical_retail?(options)
+          cedp_data_present?(options) ? add_cedp_data(post, options) : add_level_3_data(post, options)
+        end
 
         post
       end
@@ -572,11 +574,6 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_level_3_data(post, options = {})
-        if cedp_data_present?(options)
-          # CEDP/Product 3 replaces legacy Level 3 data.
-          add_cedp_data(post, options)
-          return
-        end
         return unless options[:line_items].present?
 
         post[:level3] = {}.tap do |level3|
@@ -677,7 +674,7 @@ module ActiveMerchant #:nodoc:
       end
 
       def api_version(options)
-        options[:stripe_level3_version] || options[:version] || @options[:version] || "2015-04-07"
+        options[:stripe_api_version] || options[:version] || @options[:version] || "2015-04-07"
       end
 
       def api_request(method, endpoint, parameters = nil, options = {})

--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -1015,11 +1015,6 @@ module ActiveMerchant #:nodoc:
           tags: "level3,stripe"
         )
       end
-
-      def sanitize_unit_of_measure(value)
-        sanitized = value.to_s.gsub(/[^A-Za-z0-9]/, '')[0, 12]
-        sanitized.blank? ? 'each' : sanitized
-      end
     end
   end
 end


### PR DESCRIPTION
Ticket
https://maxioevolution.atlassian.net/browse/PAY-2783

What
This PR adds a retry of the payment (which was working for level3 data, now called CEDP), deleting the CEDP data object in case of CEDP object format errors, so the payment might be successful without adding the detailed info, but notifying us on HB to remediate it at a later moment.
