### PR TITLE
Allow activesupport 8.x for Rails 8 upgrade

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = true if Gem::VERSION < '1.7.0'
 
-  s.add_dependency('activesupport', '>= 3.2.14', '< 8.0')
+  s.add_dependency('activesupport', '>= 3.2.14', '< 9.0')
   s.add_dependency('i18n', '>= 0.6.9')
   s.add_dependency('builder', '>= 2.1.2', '< 4.0.0')
   s.add_dependency('nokogiri', "~> 1.4")


### PR DESCRIPTION
Relax the `activesupport` upper bound from `< 8.0` to `< 9.0` so the gem resolves in apps on Rails 8.0.

Needed by the Maxio Payments Rails 8.0.5 upgrade (PAY-3846).

No code changes — constraint bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)