### PR TITLE
[internal] Stripe SetupIntents scaffold

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
@@ -1,0 +1,38 @@
+require File.dirname(__FILE__) + '/stripe'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # Scaffold for the SetupIntent-based Stripe ACH integration.
+    #
+    # Stripe is sunsetting the legacy Charges + Sources/Tokens API. US ACH is
+    # moving to the us_bank_account PaymentMethod + SetupIntent + PaymentIntent
+    # flow. This subclass exists so the modern Stripe API version can be pinned
+    # independently of the legacy StripeGateway, which stays on its old pinned
+    # version. The us_bank_account store/purchase/refund logic lands in a
+    # follow-up ticket; the transaction methods raise until then so the new
+    # gateway can never silently fall back to the legacy charge behaviour.
+    class StripeSetupIntentsGateway < StripeGateway
+      SETUP_INTENTS_API_VERSION = "2026-05-27.dahlia".freeze
+
+      self.display_name = "Stripe SetupIntents"
+
+      def store(_payment, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#store is not implemented yet (scaffold)"
+      end
+
+      def purchase(_money, _payment, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#purchase is not implemented yet (scaffold)"
+      end
+
+      def refund(_money, _identification, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#refund is not implemented yet (scaffold)"
+      end
+
+      private
+
+      def api_version(options = {})
+        options[:stripe_api_version] || options[:version] || @options[:version] || SETUP_INTENTS_API_VERSION
+      end
+    end
+  end
+end

--- a/test/unit/gateways/stripe_setup_intents_test.rb
+++ b/test/unit/gateways/stripe_setup_intents_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class StripeSetupIntentsTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = StripeSetupIntentsGateway.new(:login => 'login')
+  end
+
+  def test_inherits_from_stripe_gateway
+    assert_kind_of StripeGateway, @gateway
+  end
+
+  def test_pins_modern_api_version_in_request_headers
+    headers = @gateway.send(:headers)
+
+    assert_equal StripeSetupIntentsGateway::SETUP_INTENTS_API_VERSION, headers["Stripe-Version"]
+    assert_equal "2026-05-27.dahlia", headers["Stripe-Version"]
+  end
+
+  def test_legacy_stripe_gateway_version_is_unchanged
+    legacy_headers = StripeGateway.new(:login => 'login').send(:headers)
+
+    assert_equal "2015-04-07", legacy_headers["Stripe-Version"]
+  end
+
+  def test_explicit_version_option_still_overrides_the_pinned_default
+    headers = @gateway.send(:headers, :version => "2020-08-27")
+
+    assert_equal "2020-08-27", headers["Stripe-Version"]
+  end
+
+  def test_transaction_methods_are_not_implemented_in_scaffold
+    assert_raises(NotImplementedError) { @gateway.store(nil) }
+    assert_raises(NotImplementedError) { @gateway.purchase(100, nil) }
+    assert_raises(NotImplementedError) { @gateway.refund(100, nil) }
+  end
+end


### PR DESCRIPTION
### Tickets:

https://maxioevolution.atlassian.net/browse/PAY-3925

### What

Adds ActiveMerchant::Billing::StripeSetupIntentsGateway, inheriting StripeGateway. Pins the modern Stripe API version (2026-05-27.dahlia) via an api_version override — sent as the Stripe-Version header, leaving the legacy StripeGateway version (2015-04-07) untouched. Transaction methods (store/purchase/refund) raise NotImplementedError so the new gateway can never silently fall back to legacy charge behavior. Autoloaded by filename convention; no registry change needed. Unit test covers inheritance, version pinning, legacy-version isolation, explicit-version override, and the not-implemented stubs.

### Why

Stripe is sunsetting the legacy Charges/Sources API (early August); US ACH must move to the us_bank_account PaymentMethod + SetupIntent + PaymentIntent flow, which requires a modern API version. A separate gateway lets us pin that version independently of the legacy integration and retire the old path cleanly post-migration. The us_bank_account store/purchase/refund logic lands in a follow-up.