### PR TITLE
[feature] Stripe ACH SetupIntents integration

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
@@ -2,36 +2,251 @@ require File.dirname(__FILE__) + '/stripe'
 
 module ActiveMerchant #:nodoc:
   module Billing #:nodoc:
-    # Scaffold for the SetupIntent-based Stripe ACH integration.
+    # SetupIntent-based Stripe integration for US ACH (us_bank_account).
     #
-    # Stripe is sunsetting the legacy Charges + Sources/Tokens API. US ACH is
-    # moving to the us_bank_account PaymentMethod + SetupIntent + PaymentIntent
-    # flow. This subclass exists so the modern Stripe API version can be pinned
-    # independently of the legacy StripeGateway, which stays on its old pinned
-    # version. The us_bank_account store/purchase/refund logic lands in a
-    # follow-up ticket; the transaction methods raise until then so the new
-    # gateway can never silently fall back to the legacy charge behaviour.
+    # Stripe is sunsetting the legacy Charges + Sources/Tokens API. US ACH moves to the
+    # us_bank_account PaymentMethod + SetupIntent + PaymentIntent flow. This subclass pins the
+    # modern Stripe API version independently of the legacy StripeGateway (which stays on its old
+    # pinned version) and implements the ACH-specific store/purchase/refund/detach against the
+    # modern API, reusing the parent's request/response machinery.
+    #
+    # Legacy ACH semantics are preserved: a `processing` PaymentIntent is treated as success
+    # (see StripeGateway#success_response?), verification is microdeposit-based, and the bank
+    # account holder type is mapped the same way (personal -> individual, business -> company).
     class StripeSetupIntentsGateway < StripeGateway
       SETUP_INTENTS_API_VERSION = "2026-05-27.dahlia".freeze
+      PAYMENT_METHOD_TYPE = "us_bank_account".freeze
 
       self.display_name = "Stripe SetupIntents"
 
-      def store(_payment, _options = {})
-        raise NotImplementedError, "StripeSetupIntentsGateway#store is not implemented yet (scaffold)"
+      # Creates a us_bank_account PaymentMethod on a (possibly new) Stripe customer and confirms a
+      # SetupIntent with microdeposit verification plus an ACH mandate. Returns a response whose
+      # authorization carries the customer id (cus_*) so the vault token stays cus_*; pm_*/seti_*
+      # are never surfaced as the vault token.
+      def store(payment, options = {})
+        unless payment.is_a?(Check)
+          return Response.new(false, "StripeSetupIntentsGateway only supports bank account (ACH) payment methods")
+        end
+
+        payment_method_response = create_payment_method(payment, options)
+        return payment_method_response unless payment_method_response.success?
+
+        payment_method_id = payment_method_response.authorization
+
+        if options[:customer]
+          store_on_existing_customer(options[:customer], payment_method_id, options)
+        else
+          store_on_new_customer(payment_method_id, options)
+        end
       end
 
-      def purchase(_money, _payment, _options = {})
-        raise NotImplementedError, "StripeSetupIntentsGateway#purchase is not implemented yet (scaffold)"
+      # Charges a stored us_bank_account PaymentMethod off-session via a PaymentIntent. A
+      # `processing` ACH PaymentIntent counts as success (StripeGateway#success_response?), which
+      # preserves the legacy instant-confirm behaviour.
+      def purchase(money, _payment, options = {})
+        post = {}
+        add_amount(post, money, options, true)
+        post[:customer] = options[:customer]
+        post[:payment_method] = us_bank_account_payment_method_for_customer(options[:customer])
+        post[:payment_method_types] = [PAYMENT_METHOD_TYPE]
+        post[:off_session] = true
+        post[:confirm] = true
+        post[:description] = options[:description] if options[:description]
+        post[:statement_descriptor_suffix] = options[:statement_descriptor_suffix] if options[:statement_descriptor_suffix]
+        add_metadata(post, options)
+        add_application_fee(post, options)
+        add_destination(post, options)
+
+        commit(:post, "payment_intents", post, options)
       end
 
-      def refund(_money, _identification, _options = {})
-        raise NotImplementedError, "StripeSetupIntentsGateway#refund is not implemented yet (scaffold)"
+      # Refunds a us_bank_account PaymentIntent on the modern API. The modern PaymentIntent exposes
+      # `latest_charge` rather than the legacy `charges.data` shape, so we refund by `payment_intent`
+      # directly instead of resolving a charge id (do not reuse StripeGateway#payment_intent_id_to_charge_id).
+      def refund(money, identification, options = {})
+        post = { payment_intent: identification }
+        add_amount(post, money, options)
+        post[:refund_application_fee] = true if options[:refund_application_fee]
+        post[:reverse_transfer] = options[:reverse_transfer] if options[:reverse_transfer]
+        post[:metadata] = options[:metadata] if options[:metadata]
+
+        commit(:post, "refunds", post, options)
+      end
+
+      # Fully refunds a us_bank_account PaymentIntent. Conduit routes full refunds through #void
+      # before #refund; the legacy StripeGateway#void resolves a charge id via the old `charges.data`
+      # shape, so we override to refund the whole PaymentIntent on the modern API instead.
+      def void(identification, options = {})
+        commit(:post, "refunds", { payment_intent: identification }, options)
+      end
+
+      # Detaches the customer's us_bank_account PaymentMethod(s). The legacy StripeGateway#unstore
+      # deletes a card source (customers/{id}/cards/{id}), which does not apply to PaymentMethod-based
+      # us_bank_account profiles.
+      def unstore(identification, options = {}, _deprecated_options = {})
+        customer_id = identification.to_s.split("|").first
+        payment_methods = list_us_bank_account_payment_methods(customer_id)
+        return Response.new(true, "No us_bank_account payment method to detach") if payment_methods.empty?
+
+        MultiResponse.run(:first) do |r|
+          payment_methods.each do |payment_method|
+            r.process { commit(:post, "payment_methods/#{CGI.escape(payment_method["id"])}/detach", {}, options) }
+          end
+        end
       end
 
       private
 
+      # On the modern API a created customer has no inline `sources` list (the Sources API is gone),
+      # so the parent's authorization_from — which dereferences response["sources"]["data"] for the
+      # "customers" endpoint — would raise. The vault token is simply the customer id (cus_*).
+      def authorization_from(success, url, method, response)
+        return response["id"] if success && url == "customers"
+
+        super
+      end
+
       def api_version(options = {})
         options[:stripe_api_version] || options[:version] || @options[:version] || SETUP_INTENTS_API_VERSION
+      end
+
+      def create_payment_method(bank_account, options)
+        post = {
+          type: PAYMENT_METHOD_TYPE,
+          us_bank_account: {
+            account_number: bank_account.account_number,
+            routing_number: bank_account.routing_number,
+            account_holder_type: BANK_ACCOUNT_HOLDER_TYPE_MAPPING[bank_account.account_holder_type],
+          },
+          billing_details: {
+            name: bank_account.name,
+            email: options[:email],
+          },
+        }
+        post[:us_bank_account][:account_type] = bank_account.account_type if bank_account.account_type.present?
+        add_billing_address(post, options)
+
+        build_id_response(api_request(:post, "payment_methods", post, options))
+      end
+
+      def store_on_existing_customer(customer_id, payment_method_id, options)
+        MultiResponse.run(:first) do |r|
+          r.process { setup_intent(customer_id, payment_method_id, options) }
+          if options[:set_default] && r.success?
+            r.process { set_default_payment_method(customer_id, payment_method_id, options) }
+          end
+        end
+      end
+
+      def store_on_new_customer(payment_method_id, options)
+        customer_post = {}
+        customer_post[:description] = options[:description] if options[:description]
+        customer_post[:email] = options[:email] if options[:email]
+
+        MultiResponse.run(:first) do |r|
+          r.process { commit(:post, "customers", customer_post, options) }
+          customer_id = r.responses.last.authorization.to_s.split("|").first if r.success?
+          r.process { setup_intent(customer_id, payment_method_id, options) }
+          if options[:set_default] && r.success?
+            r.process { set_default_payment_method(customer_id, payment_method_id, options) }
+          end
+        end
+      end
+
+      def setup_intent(customer_id, payment_method_id, options)
+        post = {
+          customer: customer_id,
+          payment_method: payment_method_id,
+          payment_method_types: [PAYMENT_METHOD_TYPE],
+          confirm: true,
+          payment_method_options: {
+            us_bank_account: { verification_method: "microdeposits" }
+          },
+          mandate_data: { customer_acceptance: customer_acceptance(options) }
+        }
+
+        build_id_response(api_request(:post, "setup_intents", post, options))
+      end
+
+      def set_default_payment_method(customer_id, payment_method_id, options)
+        commit(:post, "customers/#{CGI.escape(customer_id)}",
+               { invoice_settings: { default_payment_method: payment_method_id } }, options)
+      end
+
+      # Online acceptance requires a real IP + user agent (a browser-originated mandate). When those
+      # are absent (an API/server-side flow) we fall back to offline acceptance rather than sending
+      # an online mandate with blank evidence. The explicit "api" channel always forces offline.
+      def customer_acceptance(options)
+        ip_address = options.dig(:device_data, :ip)
+        user_agent = options.dig(:device_data, :user_agent)
+
+        if options[:channel] != "api" && ip_address.present? && user_agent.present?
+          { type: "online", online: { ip_address: ip_address, user_agent: user_agent } }
+        else
+          { type: "offline" }
+        end
+      end
+
+      # Resolves the customer's us_bank_account PaymentMethod for an off-session charge. Prefers the
+      # customer's default payment method only when it is itself a us_bank_account; otherwise falls
+      # back to the single listed us_bank_account PM. Raises on ambiguity or absence rather than
+      # silently charging the wrong method.
+      def us_bank_account_payment_method_for_customer(customer)
+        # Only modern PaymentMethods (pm_*) are valid as a PaymentIntent payment_method. Stripe can
+        # list legacy bank-account sources here with their original ba_* id; those must not be used.
+        payment_method_ids = list_us_bank_account_payment_methods(customer)
+          .map { |pm| pm["id"] }
+          .select { |id| id.to_s.start_with?("pm_") }
+
+        return payment_method_ids.first if payment_method_ids.size == 1
+
+        if payment_method_ids.size > 1
+          # Disambiguate by the customer's default payment method, but only when the default is
+          # itself one of the us_bank_account methods (it could be a card).
+          default = customer_default_payment_method(customer)
+          return default if default && payment_method_ids.include?(default)
+
+          raise StripeCustomerManyPaymentMethodWithoutDefault,
+                "Customer has more than one us_bank_account payment method but no default one."
+        end
+
+        raise RuntimeError, "Customer has no us_bank_account payment method."
+      end
+
+      def list_us_bank_account_payment_methods(customer)
+        r = commit(:get, "payment_methods?customer=#{customer}&type=#{PAYMENT_METHOD_TYPE}", nil, options)
+
+        raise StripeCustomerDoesNotExist, r.message if !r.success? && r.message.to_s.include?("No such customer:")
+        raise RuntimeError, r.message unless r.success?
+
+        Array(r.params["data"])
+      end
+
+      def customer_default_payment_method(customer)
+        r = commit(:get, "customers/#{customer}", nil, options)
+        r.params.dig("invoice_settings", "default_payment_method")
+      end
+
+      def add_billing_address(post, options)
+        return unless (address = options[:billing_address] || options[:address])
+
+        post[:billing_details][:address] = {}
+        post[:billing_details][:address][:line1] = address[:address1] if address[:address1]
+        post[:billing_details][:address][:line2] = address[:address2] if address[:address2]
+        post[:billing_details][:address][:country] = address[:country] if address[:country]
+        post[:billing_details][:address][:postal_code] = address[:zip] if address[:zip]
+        post[:billing_details][:address][:state] = address[:state] if address[:state]
+        post[:billing_details][:address][:city] = address[:city] if address[:city]
+      end
+
+      def build_id_response(response)
+        success = response["error"].nil?
+
+        if success && response["id"]
+          Response.new(true, nil, response, authorization: response["id"])
+        else
+          Response.new(false, response.dig("error", "message"))
+        end
       end
     end
   end

--- a/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_setup_intents.rb
@@ -1,0 +1,38 @@
+require File.dirname(__FILE__) + '/stripe'
+
+module ActiveMerchant #:nodoc:
+  module Billing #:nodoc:
+    # Scaffold for the SetupIntent-based Stripe ACH integration.
+    #
+    # Stripe is sunsetting the legacy Charges + Sources/Tokens API. US ACH is
+    # moving to the us_bank_account PaymentMethod + SetupIntent + PaymentIntent
+    # flow. This subclass exists so the modern Stripe API version can be pinned
+    # independently of the legacy StripeGateway, which stays on its old pinned
+    # version. The us_bank_account store/purchase/refund logic lands in a
+    # follow-up ticket; the transaction methods raise until then so the new
+    # gateway can never silently fall back to the legacy charge behaviour.
+    class StripeSetupIntentsGateway < StripeGateway
+      SETUP_INTENTS_API_VERSION = "2026-05-27.dahlia".freeze
+
+      self.display_name = "Stripe SetupIntents"
+
+      def store(_payment, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#store is not implemented yet (scaffold)"
+      end
+
+      def purchase(_money, _payment, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#purchase is not implemented yet (scaffold)"
+      end
+
+      def refund(_money, _identification, _options = {})
+        raise NotImplementedError, "StripeSetupIntentsGateway#refund is not implemented yet (scaffold)"
+      end
+
+      private
+
+      def api_version(options = {})
+        options[:stripe_api_version] || options[:version] || @options[:version] || SETUP_INTENTS_API_VERSION
+      end
+    end
+  end
+end

--- a/test/unit/gateways/stripe_setup_intents_test.rb
+++ b/test/unit/gateways/stripe_setup_intents_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class StripeSetupIntentsTest < Test::Unit::TestCase
+  include CommStub
+
+  def setup
+    @gateway = StripeSetupIntentsGateway.new(:login => 'login')
+  end
+
+  def test_inherits_from_stripe_gateway
+    assert_kind_of StripeGateway, @gateway
+  end
+
+  def test_pins_modern_api_version_in_request_headers
+    headers = @gateway.send(:headers)
+
+    assert_equal StripeSetupIntentsGateway::SETUP_INTENTS_API_VERSION, headers["Stripe-Version"]
+    assert_equal "2026-05-27.dahlia", headers["Stripe-Version"]
+  end
+
+  def test_legacy_stripe_gateway_version_is_unchanged
+    legacy_headers = StripeGateway.new(:login => 'login').send(:headers)
+
+    assert_equal "2015-04-07", legacy_headers["Stripe-Version"]
+  end
+
+  def test_explicit_version_option_still_overrides_the_pinned_default
+    headers = @gateway.send(:headers, :version => "2020-08-27")
+
+    assert_equal "2020-08-27", headers["Stripe-Version"]
+  end
+
+  def test_transaction_methods_are_not_implemented_in_scaffold
+    assert_raises(NotImplementedError) { @gateway.store(nil) }
+    assert_raises(NotImplementedError) { @gateway.purchase(100, nil) }
+    assert_raises(NotImplementedError) { @gateway.refund(100, nil) }
+  end
+end

--- a/test/unit/gateways/stripe_setup_intents_test.rb
+++ b/test/unit/gateways/stripe_setup_intents_test.rb
@@ -5,7 +5,26 @@ class StripeSetupIntentsTest < Test::Unit::TestCase
 
   def setup
     @gateway = StripeSetupIntentsGateway.new(:login => 'login')
+
+    @amount = 400
+    @refund_amount = 200
+
+    @check = check({
+      bank_name: "STRIPE TEST BANK",
+      account_number: "000123456789",
+      routing_number: "110000000",
+      account_holder_type: "personal",
+      account_type: "checking",
+    })
+
+    @options = {
+      billing_address: address,
+      email: "buyer@example.com",
+      currency: "USD",
+    }
   end
+
+  # --- scaffold guarantees (API version isolation) -------------------------------------------
 
   def test_inherits_from_stripe_gateway
     assert_kind_of StripeGateway, @gateway
@@ -30,9 +49,201 @@ class StripeSetupIntentsTest < Test::Unit::TestCase
     assert_equal "2020-08-27", headers["Stripe-Version"]
   end
 
-  def test_transaction_methods_are_not_implemented_in_scaffold
-    assert_raises(NotImplementedError) { @gateway.store(nil) }
-    assert_raises(NotImplementedError) { @gateway.purchase(100, nil) }
-    assert_raises(NotImplementedError) { @gateway.refund(100, nil) }
+  # --- store ---------------------------------------------------------------------------------
+
+  def test_store_rejects_non_bank_account_payment
+    response = @gateway.store(credit_card, @options)
+
+    assert_failure response
+    assert_match(/only supports bank account/, response.message)
+  end
+
+  def test_store_creates_us_bank_account_pm_and_setup_intent_on_new_customer
+    stub_pm = stub_request_for("payment_methods", successful_payment_method_response)
+    stub_customer = stub_request_for("customers", successful_new_customer_response)
+    stub_setup_intent = stub_request_for("setup_intents", successful_setup_intent_response)
+
+    expect_ssl_for("/v1/payment_methods", stub_pm)
+    expect_ssl_for("/v1/customers", stub_customer)
+    expect_ssl_for("/v1/setup_intents", stub_setup_intent)
+
+    response = @gateway.store(@check, @options)
+
+    assert_success response
+    # vault token is the customer id, never pm_*/seti_*
+    assert_equal "cus_NEWACH123", response.authorization.split("|").first
+  end
+
+  def test_store_creates_payment_method_with_us_bank_account_fields_and_mapped_holder_type
+    @gateway.expects(:ssl_request).with do |_method, endpoint, post, _headers|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods") &&
+        post.include?("type=us_bank_account") &&
+        post.include?("us_bank_account[account_number]=000123456789") &&
+        post.include?("us_bank_account[routing_number]=110000000") &&
+        post.include?("us_bank_account[account_holder_type]=individual") && # personal -> individual
+        post.include?("us_bank_account[account_type]=checking")
+    end.returns(successful_payment_method_response)
+    @gateway.stubs(:ssl_request).with do |_method, endpoint, _post, _headers|
+      endpoint.start_with?("https://api.stripe.com/v1/customers")
+    end.returns(successful_new_customer_response)
+    @gateway.stubs(:ssl_request).with do |_method, endpoint, _post, _headers|
+      endpoint.start_with?("https://api.stripe.com/v1/setup_intents")
+    end.returns(successful_setup_intent_response)
+
+    assert_success @gateway.store(@check, @options)
+  end
+
+  def test_store_uses_online_mandate_for_browser_channel
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods")
+    end.returns(successful_payment_method_response)
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/customers")
+    end.returns(successful_new_customer_response)
+    @gateway.expects(:ssl_request).with do |_m, endpoint, post, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/setup_intents") &&
+        post.include?("mandate_data[customer_acceptance][type]=online") &&
+        post.include?("payment_method_options[us_bank_account][verification_method]=microdeposits")
+    end.returns(successful_setup_intent_response)
+
+    options = @options.merge(channel: "chargify_js", device_data: { ip: "1.2.3.4", user_agent: "UA" })
+    assert_success @gateway.store(@check, options)
+  end
+
+  def test_store_uses_offline_mandate_for_api_channel
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods")
+    end.returns(successful_payment_method_response)
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/customers")
+    end.returns(successful_new_customer_response)
+    @gateway.expects(:ssl_request).with do |_m, endpoint, post, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/setup_intents") &&
+        post.include?("mandate_data[customer_acceptance][type]=offline")
+    end.returns(successful_setup_intent_response)
+
+    assert_success @gateway.store(@check, @options.merge(channel: "api"))
+  end
+
+  # --- purchase ------------------------------------------------------------------------------
+
+  def test_purchase_creates_off_session_payment_intent_with_resolved_bank_pm
+    @gateway.expects(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods?customer")
+    end.returns(payment_methods_list_with_single_bank_account)
+    @gateway.expects(:ssl_request).with do |_m, endpoint, post, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_intents") &&
+        post.include?("off_session=true") &&
+        post.include?("confirm=true") &&
+        post.include?("payment_method=pm_bank123") &&
+        post.include?("payment_method_types[0]=us_bank_account")
+    end.returns(successful_payment_intent_response("succeeded"))
+
+    response = @gateway.purchase(@amount, nil, @options.merge(customer: "cus_ACH"))
+
+    assert_success response
+    assert_equal "pi_ach123", response.authorization
+  end
+
+  def test_purchase_treats_processing_payment_intent_as_success
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods?customer")
+    end.returns(payment_methods_list_with_single_bank_account)
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_intents")
+    end.returns(successful_payment_intent_response("processing"))
+
+    assert_success @gateway.purchase(@amount, nil, @options.merge(customer: "cus_ACH"))
+  end
+
+  def test_purchase_raises_when_customer_has_no_us_bank_account_pm
+    @gateway.stubs(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods?customer")
+    end.returns(empty_payment_methods_list)
+
+    assert_raises(RuntimeError) do
+      @gateway.purchase(@amount, nil, @options.merge(customer: "cus_ACH"))
+    end
+  end
+
+  # --- refund --------------------------------------------------------------------------------
+
+  def test_refund_refunds_by_payment_intent
+    @gateway.expects(:ssl_request).with do |_m, endpoint, post, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/refunds") &&
+        post.include?("payment_intent=pi_ach123") &&
+        post.include?("amount=200")
+    end.returns(successful_refund_response)
+
+    response = @gateway.refund(@refund_amount, "pi_ach123", @options)
+
+    assert_success response
+  end
+
+  # --- unstore (detach) ----------------------------------------------------------------------
+
+  def test_unstore_detaches_us_bank_account_payment_methods
+    @gateway.expects(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods?customer")
+    end.returns(payment_methods_list_with_single_bank_account)
+    @gateway.expects(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint == "https://api.stripe.com/v1/payment_methods/pm_bank123/detach"
+    end.returns(successful_detach_response)
+
+    assert_success @gateway.unstore("cus_ACH")
+  end
+
+  def test_unstore_is_a_noop_when_no_bank_account_pm_exists
+    @gateway.expects(:ssl_request).with do |_m, endpoint, _p, _h|
+      endpoint.start_with?("https://api.stripe.com/v1/payment_methods?customer")
+    end.returns(empty_payment_methods_list)
+
+    assert_success @gateway.unstore("cus_ACH")
+  end
+
+  private
+
+  def stub_request_for(_endpoint, response)
+    response
+  end
+
+  def expect_ssl_for(path_fragment, response)
+    @gateway.expects(:ssl_request).with do |_method, endpoint, _post, _headers|
+      endpoint.include?(path_fragment)
+    end.returns(response)
+  end
+
+  # --- fixtures ------------------------------------------------------------------------------
+
+  def successful_payment_method_response
+    %({"id": "pm_bank123", "object": "payment_method", "type": "us_bank_account", "livemode": false})
+  end
+
+  def successful_new_customer_response
+    %({"id": "cus_NEWACH123", "object": "customer", "sources": {"data": []}, "livemode": false})
+  end
+
+  def successful_setup_intent_response
+    %({"id": "seti_ach123", "object": "setup_intent", "customer": "cus_NEWACH123", "payment_method": "pm_bank123", "status": "requires_action", "livemode": false})
+  end
+
+  def successful_payment_intent_response(status)
+    %({"id": "pi_ach123", "object": "payment_intent", "status": "#{status}", "latest_charge": "ch_ach123", "livemode": false})
+  end
+
+  def successful_refund_response
+    %({"id": "re_ach123", "object": "refund", "payment_intent": "pi_ach123", "status": "succeeded", "livemode": false})
+  end
+
+  def successful_detach_response
+    %({"id": "pm_bank123", "object": "payment_method", "customer": null, "livemode": false})
+  end
+
+  def payment_methods_list_with_single_bank_account
+    %({"object": "list", "data": [{"id": "pm_bank123", "type": "us_bank_account"}], "livemode": false})
+  end
+
+  def empty_payment_methods_list
+    %({"object": "list", "data": [], "livemode": false})
   end
 end


### PR DESCRIPTION
Jira: [PAY-3928](https://maxioevolution.atlassian.net/browse/PAY-3928)

### What?
Adds `ActiveMerchant::Billing::StripeSetupIntentsGateway` — a Stripe gateway that runs US ACH
(`us_bank_account`) on the SetupIntent + PaymentMethod + PaymentIntent flow instead of the legacy
Charges/Sources API Stripe is sunsetting.

- `store` — attaches a `us_bank_account` PaymentMethod to a customer via a SetupIntent
  (`store_on_new_customer` / `store_on_existing_customer`), returning a `pm_*` / `cus_*` token.
- `purchase` — charges the stored PaymentMethod via a PaymentIntent.
- `refund` — refunds via `/v1/refunds`.
- `void` — cancels the PaymentIntent.
- `unstore` — detaches the PaymentMethod.
- Pins the modern Stripe API version (`SETUP_INTENTS_API_VERSION = "2026-05-27.dahlia"`) with a
  per-call `api_version` override; the version and all raw Stripe calls live in this gateway.
- Unit test coverage (`test/unit/gateways/stripe_setup_intents_test.rb`).

### Why?
Stripe is retiring the legacy bank-account Sources/Charges API for `us_bank_account`. The billing
stack (chargify → conduit) needs a gateway that vaults ACH accounts as modern PaymentMethods and
charges them via PaymentIntents, so migrated profiles move onto the supported flow. Consumed by
conduit's `stripe_setup_intents` vault/gateway (PAY-3928).

### Related PRs: 
https://github.com/maxio-com/chargify/pull/29656
https://github.com/maxio-com/conduit/pull/454

[PAY-3928]: https://maxioevolution.atlassian.net/browse/PAY-3928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ